### PR TITLE
fix: remove working directory from workflow

### DIFF
--- a/.github/workflows/build_and_scan_rock.yaml
+++ b/.github/workflows/build_and_scan_rock.yaml
@@ -62,7 +62,6 @@ jobs:
 
             # send scans from supplied directory
             ./kubeflow-ci/scripts/cve-reports/send-scan.py --report-path=\"${{ inputs.rock }}\" --jira-url=\"${{ secrets.JIRA_URL }}\"
-        working-directory: ${{ inputs.rock }}
       - name: Prepare artifacts
         run: |
           tar zcvf trivy-report-${{ inputs.rock }}.tar.gz trivy-report-${{ inputs.rock }}.json


### PR DESCRIPTION
Wroking directory is incorrectly set in workflow. Needs to be removed.

Summary of changes:
- Removed working directory from sending scan step of workflow. Not needed.