### PR TITLE
feat: accept packed_charms in bundle and integration jobs

### DIFF
--- a/.github/workflows/_bundle.yaml
+++ b/.github/workflows/_bundle.yaml
@@ -36,12 +36,10 @@ jobs:
       - name: Run test
         run: |
           # Requires the model to be called kubeflow
-          export CI_PACKED_CHARMS=${{ inputs.packed-charms }}
-          echo ${{ inputs.packed-charms }}
           juju add-model kubeflow
           tox -e bundle-integration -- --model kubeflow
-          # env:
-          #   CI_PACKED_CHARMS: ${{ inputs.packed-charms }}
+          env:
+            CI_PACKED_CHARMS: ${{ fromJSON(inputs.packed-charms) }}
 
       - name: Collect charm debug artifacts
         uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main

--- a/.github/workflows/_bundle.yaml
+++ b/.github/workflows/_bundle.yaml
@@ -5,8 +5,11 @@ on:
   workflow_call:
     inputs:
       packed-charms:
-        description: List of packed charms by the build_charms_with_cache action.
-        type: environment
+        description: List of packed charms by the build_charms_with_cache action (JSON string).
+        type: string
+      charms-artefact-name:
+        description: GitHub artefact name where charms are uploaded.
+        type: string
 jobs:
   test-bundle:
     name: Test the bundle
@@ -23,6 +26,12 @@ jobs:
           juju-channel: 2.9/stable
           bootstrap-options: --agent-version="2.9.43"
           microk8s-addons: "dns storage rbac metallb:'10.64.140.43-10.64.140.49,192.168.0.105-192.168.0.111'"
+
+      - name: Download packed charm(s)
+        uses: actions/download-artifact@v3
+        if: charms-artefact-name
+        with:
+          name: ${{ inputs.charms-artefact-name }}
 
       - name: Run test
         run: |

--- a/.github/workflows/_bundle.yaml
+++ b/.github/workflows/_bundle.yaml
@@ -39,7 +39,7 @@ jobs:
           juju add-model kubeflow
           tox -e bundle-integration -- --model kubeflow
           env:
-            CI_PACKED_CHARMS: ${{ fromJSON(inputs.packed-charms) }}
+            CI_PACKED_CHARMS: ${{ toJSON(inputs.packed-charms) }}
 
       - name: Collect charm debug artifacts
         uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main

--- a/.github/workflows/_bundle.yaml
+++ b/.github/workflows/_bundle.yaml
@@ -39,7 +39,7 @@ jobs:
           juju add-model kubeflow
           tox -e bundle-integration -- --model kubeflow
         env:
-          CI_PACKED_CHARMS: ${{ inputs.packed_charms }}
+          CI_PACKED_CHARMS: ${{ inputs.packed-charms }}
 
       - name: Collect charm debug artifacts
         uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main

--- a/.github/workflows/_bundle.yaml
+++ b/.github/workflows/_bundle.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Download packed charm(s)
         uses: actions/download-artifact@v3
-        if: charms-artefact-name
+        if: ${{ inputs.charms-artefact-name }}
         with:
           name: ${{ inputs.charms-artefact-name }}
 

--- a/.github/workflows/_bundle.yaml
+++ b/.github/workflows/_bundle.yaml
@@ -36,10 +36,12 @@ jobs:
       - name: Run test
         run: |
           # Requires the model to be called kubeflow
+          export CI_PACKED_CHARMS=${{ inputs.packed-charms }}
+          echo ${{ inputs.packed-charms }}
           juju add-model kubeflow
           tox -e bundle-integration -- --model kubeflow
-        env:
-          CI_PACKED_CHARMS: ${{ inputs.packed-charms }}
+          # env:
+          #   CI_PACKED_CHARMS: ${{ inputs.packed-charms }}
 
       - name: Collect charm debug artifacts
         uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main

--- a/.github/workflows/_bundle.yaml
+++ b/.github/workflows/_bundle.yaml
@@ -3,7 +3,10 @@ name: Bundle Test
 
 on:
   workflow_call:
-
+    inputs:
+      packed-charms:
+        description: List of packed charms by the build_charms_with_cache action.
+        type: environment
 jobs:
   test-bundle:
     name: Test the bundle
@@ -26,6 +29,8 @@ jobs:
           # Requires the model to be called kubeflow
           juju add-model kubeflow
           tox -e bundle-integration -- --model kubeflow
+        env:
+          CI_PACKED_CHARMS: ${{ inputs.packed_charms }}
 
       - name: Collect charm debug artifacts
         uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main

--- a/.github/workflows/_integration-tests.yaml
+++ b/.github/workflows/_integration-tests.yaml
@@ -7,6 +7,9 @@ on:
       charm-name:
         required: true
         type: string
+      packed-charms:
+        description: List of packed charms by the build_charms_with_cache action.
+        type: environment
 
 jobs:
   integration:
@@ -34,6 +37,8 @@ jobs:
           # Requires the model to be called kubeflow
           juju add-model kubeflow
           sg microk8s -c "tox -e ${{ inputs.charm-name }}-integration"
+        env:
+          CI_PACKED_CHARMS: ${{ inputs.packed_charms }}
 
       - name: Collect charm debug artifacts
         uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main

--- a/.github/workflows/_integration-tests.yaml
+++ b/.github/workflows/_integration-tests.yaml
@@ -46,7 +46,7 @@ jobs:
           juju add-model kubeflow
           sg microk8s -c "tox -e ${{ inputs.charm-name }}-integration"
         env:
-          CI_PACKED_CHARMS: ${{ fromJSON(inputs.packed-charms) }}
+          CI_PACKED_CHARMS: ${{ toJSON(inputs.packed-charms) }}
 
       - name: Collect charm debug artifacts
         uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main

--- a/.github/workflows/_integration-tests.yaml
+++ b/.github/workflows/_integration-tests.yaml
@@ -46,7 +46,7 @@ jobs:
           juju add-model kubeflow
           sg microk8s -c "tox -e ${{ inputs.charm-name }}-integration"
         env:
-          CI_PACKED_CHARMS: ${{ inputs.packed-charms }}
+          CI_PACKED_CHARMS: ${{ fromJSON(inputs.packed-charms) }}
 
       - name: Collect charm debug artifacts
         uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main

--- a/.github/workflows/_integration-tests.yaml
+++ b/.github/workflows/_integration-tests.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Download packed charm(s)
         uses: actions/download-artifact@v3
-        if: charms-artefact-name
+        if: ${{ inputs.charms-artefact-name }}
         with:
           name: ${{ inputs.charms-artefact-name }}
 

--- a/.github/workflows/_integration-tests.yaml
+++ b/.github/workflows/_integration-tests.yaml
@@ -46,7 +46,7 @@ jobs:
           juju add-model kubeflow
           sg microk8s -c "tox -e ${{ inputs.charm-name }}-integration"
         env:
-          CI_PACKED_CHARMS: ${{ inputs.packed_charms }}
+          CI_PACKED_CHARMS: ${{ inputs.packed-charms }}
 
       - name: Collect charm debug artifacts
         uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main

--- a/.github/workflows/_integration-tests.yaml
+++ b/.github/workflows/_integration-tests.yaml
@@ -8,8 +8,11 @@ on:
         required: true
         type: string
       packed-charms:
-        description: List of packed charms by the build_charms_with_cache action.
-        type: environment
+        description: List of packed charms by the build_charms_with_cache action (JSON string).
+        type: string
+      charms-artefact-name:
+        description: GitHub artefact name where charms are uploaded.
+        type: string
 
 jobs:
   integration:
@@ -26,11 +29,16 @@ jobs:
           bootstrap-options: --agent-version="2.9.43"
           microk8s-addons: "dns storage rbac metallb:'10.64.140.43-10.64.140.49,192.168.0.105-192.168.0.111'"
 
-
       # TODO: Remove once https://bugs.launchpad.net/juju/+bug/2024897 is fixed
       - name: Refresh Juju snap
         run: |
           sudo snap refresh juju --revision 22345
+
+      - name: Download packed charm(s)
+        uses: actions/download-artifact@v3
+        if: charms-artefact-name
+        with:
+          name: ${{ inputs.charms-artefact-name }}
 
       - name: Run integration test
         run: |


### PR DESCRIPTION
This this variable, the bundle and integration jobs will be able to receive a list of packed charms that can be used by the test suite for using them, avoiding the need for building all charms every time a new job is run. For example: a repository CI has two integration test suites, but both of them build the same charms.

This PR looks for compatibility with the [build_charms_with_cache](https://github.com/canonical/data-platform-workflows/blob/main/.github/workflows/build_charms_with_cache.yaml) action.