### PR TITLE
fix: fix: remove charm-name from inputs of quality-checks

### DIFF
--- a/.github/workflows/_quality-checks.yaml
+++ b/.github/workflows/_quality-checks.yaml
@@ -7,9 +7,6 @@ on:
       charm-path:
         required: true
         type: string
-      charm-name:
-        required: true
-        type: string
 
 jobs:
   lib-check:
@@ -32,4 +29,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: python3 -m pip install tox
-      - run: tox -e ${{ inputs.charm-name }}-lint
+      - run: tox -c ${{ inputs.charm-path }} -e lint


### PR DESCRIPTION
The charm-name is not really necessary for running quality checks, the charm-path is enough as each of the charm directories for both single and multi-charms repos have tox environments for each of the checks. This option will break v1 of this workflow, but will keep compatibility with v0.

