### PR TITLE
fix(build_and_publish_rock): Remove workflow_dispatch

### DIFF
--- a/.github/workflows/build_and_publish_rock.yaml
+++ b/.github/workflows/build_and_publish_rock.yaml
@@ -17,23 +17,6 @@ on:
         required: true
       DOCKER_PASSWORD:
         required: true
-  workflow_dispatch:
-    inputs:
-      rockcraft-dir:
-        description: "Path to rock directory, i.e. directory containing rockcraft.yaml"
-        required: true
-        default: '.'
-        type: string
-      source-branch:
-        description: Github branch from this repo to publish.  If blank, will use the default branch
-        default: ''
-        required: false
-        type: string
-    secrets:
-      DOCKER_USERNAME:
-        required: true
-      DOCKER_PASSWORD:
-        required: true
 
 jobs:
   build-and-publish-rock:


### PR DESCRIPTION
Remove `workflow_dispatch` since there is no use for it in this repo.
On top of that, it contained a `secrets` field which would return an 
"Unexpected value 'secrets'" since this is not an allowed field.