### PR TITLE
feat: Add workflow to get modified ROCKs and build-scan-test them

### DIFF
--- a/.github/workflows/get_rocks_modified_and_build_scan_test.yaml
+++ b/.github/workflows/get_rocks_modified_and_build_scan_test.yaml
@@ -1,0 +1,51 @@
+name: Get ROCKs modified and build-scan-test them
+
+on:
+  workflow_call:
+
+jobs:
+  get-all-rock-paths:
+    name: Get all rockcraft.yaml paths
+    runs-on: ubuntu-22.04
+    outputs:
+      paths: ${{ steps.find.outputs.paths}}
+    steps:
+      - name: Checkout repository code
+        uses: actions/checkout@v3
+      - name: Get all rockcraft.yaml paths using find
+        id: find
+        run: |
+          paths=$(find ./ -name "rockcraft.yaml" -printf "%h:\n  - '%h/**'\n" | sed 's/\.\///g')
+          echo "Paths found:"
+          echo "${paths}"
+          # Passing multi-line string to output requires the use of a delimiter
+          echo "paths<<EOF" >> $GITHUB_OUTPUT
+          echo "${paths}" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+  changes:
+    name: Get paths for ROCKs modified by PR
+    needs: get-all-rock-paths
+    runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: read
+    # Set job outputs to values from filter step
+    outputs:
+      rock_paths: ${{ steps.filter.outputs.changes }}
+    steps:
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: ${{ needs.get-all-rock-paths.outputs.paths}}
+
+  build-scan-test-rock:
+    name: Build, scan and test
+    needs: changes
+    strategy:
+      fail-fast: false
+      matrix:
+        rock-dir: ${{ fromJson(needs.changes.outputs.rock_paths) }}
+    uses: ./.github/workflows/build_scan_and_test_rock.yaml
+    secrets: inherit
+    with:
+      rock-dir: ${{ matrix.rock-dir }}


### PR DESCRIPTION
Add workflow that get modified ROCKs by PR and then triggers build_scan_test.yaml workflow for each one of these. This PR came after a refactor to https://github.com/canonical/seldonio-rocks/pull/64.

Ref https://github.com/canonical/bundle-kubeflow/issues/692
Ref also https://github.com/canonical/seldonio-rocks/issues/58 due to the refactoring