### PR TITLE
fix: Update `build_scan_and_test_rock.yaml` to not remove docker images

### DIFF
--- a/.github/workflows/build_scan_and_test_rock.yaml
+++ b/.github/workflows/build_scan_and_test_rock.yaml
@@ -35,7 +35,6 @@ jobs:
           remove-haskell: 'true'
           remove-android: 'true'
           remove-codeql: 'true'
-          remove-docker-images: 'true'
 
       - name: Check out code
         uses: actions/checkout@v3


### PR DESCRIPTION
Fix trivy scanning failures due to `maximize-build-space` action deleting
the image that the action was running in.

Closes https://github.com/canonical/charmed-kubeflow-workflows/issues/33
