### PR TITLE
fix(rocks): publish rock only on push events

### DIFF
--- a/.github/workflows/build-scan-test-publish-rock.yaml
+++ b/.github/workflows/build-scan-test-publish-rock.yaml
@@ -60,7 +60,7 @@ jobs:
       python-version: ${{ inputs.python-version }}
 
   publish:
-    if: ${{ github.event_name }} == 'push'
+    if: ${{ github.event_name == 'push' }}
     needs: [scan, build, sanity-tests, integration-tests]
     uses: ./.github/workflows/publish-rock.yaml
     secrets: inherit


### PR DESCRIPTION
Trigger `publish-rock` job only on `push` events.