### PR TITLE
integration-test-rock.yaml: Implement save space steps

### DIFF
--- a/.github/workflows/integration-test-rock.yaml
+++ b/.github/workflows/integration-test-rock.yaml
@@ -74,6 +74,9 @@ jobs:
           sudo skopeo --insecure-policy copy oci-archive:${{ inputs.rock-filename }} docker-daemon:${{ inputs.rock-reference }}
           echo "image=${{ inputs.rock-reference }}" >> "$GITHUB_OUTPUT"
 
+      - name: Clean up .rock file
+        run: rm ${{ inputs.rock-filename }}
+
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:

--- a/.github/workflows/integration-test-rock.yaml
+++ b/.github/workflows/integration-test-rock.yaml
@@ -46,6 +46,16 @@ jobs:
     name: Test ${{ inputs.rock-reference }}
     runs-on: ubuntu-22.04
     steps:
+      - name: Maximise GH runner space
+        uses: easimon/maximize-build-space@v7
+        with:
+          root-reserve-mb: 40960
+          remove-dotnet: 'true'
+          remove-haskell: 'true'
+          remove-android: 'true'
+          remove-codeql: 'true'
+          remove-docker-images: 'true'
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Save space during integration-test-rock.yaml since this can fail when having to do with large images. See issue for details

Example run https://github.com/canonical/seldonio-rocks/actions/runs/7460461633/job/20299668263?pr=66#step:9:20

Closes https://github.com/canonical/charmed-kubeflow-workflows/issues/39