### PR TITLE
build-rock: Add rockcraft-channel option

### DIFF
--- a/.github/workflows/build-rock.yaml
+++ b/.github/workflows/build-rock.yaml
@@ -7,6 +7,11 @@ on:
         description: "Path to rock directory, i.e. directory containing rockcraft.yaml"
         required: true
         type: string
+      rockcraft-channel:
+        description: "Rockcraft channel e.g. latest/stable"
+        required: true
+        default: "latest/stable"
+        type: string
       source-branch:
         description: Github branch to checkout. If blank, it will use default values.
         default: '' # For default behaviour, see https://github.com/actions/checkout/tree/v4/#usage
@@ -55,6 +60,7 @@ jobs:
         id: rockcraft
         with:
           path: ./${{ inputs.rock-dir }}
+          rockcraft-channel: ${{ inputs.rockcraft-channel }}
 
       - name: Output rock filename
         id: metadata

--- a/.github/workflows/build-scan-test-publish-rock.yaml
+++ b/.github/workflows/build-scan-test-publish-rock.yaml
@@ -7,6 +7,11 @@ on:
         description: "Path to rock directory, i.e. directory containing rockcraft.yaml"
         required: true
         type: string
+      rockcraft-channel:
+        description: "Rockcraft channel e.g. latest/stable"
+        required: true
+        default: "latest/stable"
+        type: string
       microk8s-channel:
         description: "Microk8s channel e.g. 1.26/stable"
         required: true
@@ -28,6 +33,7 @@ jobs:
     uses: ./.github/workflows/build-rock.yaml
     with:
       rock-dir: ${{ inputs.rock-dir }}
+      rockcraft-channel: ${{ inputs.rockcraft-channel }}
 
   scan:
     needs: build

--- a/.github/workflows/get-rocks-modified-and-build-scan-test-publish.yaml
+++ b/.github/workflows/get-rocks-modified-and-build-scan-test-publish.yaml
@@ -3,6 +3,11 @@ name: Get ROCKs modified and build-scan-test-publish them
 on:
   workflow_call:
     inputs:
+      rockcraft-channel:
+        description: "Rockcraft channel e.g. latest/stable"
+        required: false
+        default: "latest/stable"
+        type: string
       microk8s-channel:
         description: "Microk8s channel e.g. 1.26/stable"
         required: true
@@ -36,4 +41,5 @@ jobs:
       rock-dir: ${{ matrix.rock-dir }}
       microk8s-channel: ${{ inputs.microk8s-channel }}
       juju-channel: ${{ inputs.juju-channel }}
+      rockcraft-channel: ${{ inputs.rockcraft-channel }}
       python-version: ${{ inputs.python-version }}

--- a/templates/on-pull-request-rocks-template.yaml
+++ b/templates/on-pull-request-rocks-template.yaml
@@ -1,6 +1,8 @@
 # Meant to be copied over as is in all ROCKs repositories with
 # the name `on_pull_request.yaml` after adjusting microk8s and 
 # juju channels and uncommenting/remove python-version input.
+# If rockcraft-channel is omitted, it will install from stable 
+# by default
 name: On Pull Request
 
 on:
@@ -15,6 +17,7 @@ jobs:
       pull-requests: read
     secrets: inherit
     with:
+      # rockcraft-channel: latest/edge
       microk8s-channel: 1.24/stable
       juju-channel: 2.9/stable
       # python-version: "3.8"

--- a/templates/on-push-rock-template.yaml
+++ b/templates/on-push-rock-template.yaml
@@ -1,6 +1,8 @@
 # Meant to be copied over as is in all ROCKs repositories with
 # the name `on_push.yaml` after adjusting microk8s and 
 # juju channels and uncommenting/remove python-version input.
+# If rockcraft-channel is omitted, it will install from stable 
+# by default
 name: On Push
 
 on:
@@ -18,6 +20,7 @@ jobs:
       pull-requests: read
     secrets: inherit
     with:
+      # rockcraft-channel: latest/edge
       microk8s-channel: 1.24/stable
       juju-channel: 2.9/stable
       # python-version: "3.8"


### PR DESCRIPTION
Add rockcraft-channel option as an option for the ROCKs CI workflows. We need this in order to use newly introduced features from rockcraft, otherwise it will by default pull from `stable`.

Ref #36