### PR TITLE
Update get-rocks-modified-and-build-scan-test-publish.yaml to allow defaults for `microk8s` and `juju-channel`

### DIFF
--- a/.github/workflows/get-rocks-modified-and-build-scan-test-publish.yaml
+++ b/.github/workflows/get-rocks-modified-and-build-scan-test-publish.yaml
@@ -10,12 +10,12 @@ on:
         type: string
       microk8s-channel:
         description: "Microk8s channel e.g. 1.26/stable"
-        required: true
+        required: false
         default: "1.26/stable"
         type: string
       juju-channel:
         description: "Juju channel e.g. 3.1/stable"
-        required: true
+        required: false
         default: "3.1/stable"
         type: string
       python-version:


### PR DESCRIPTION
This sets `microk8s-channel` and `juju-channel` to not be required.  They have default values already so afaict they can be optional.  