### PR TITLE
fix, ci: set root-reserve-mb to 29696 in maximise GH runner step

### DIFF
--- a/.github/workflows/build-rock.yaml
+++ b/.github/workflows/build-rock.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Maximise GH runner space
         uses: easimon/maximize-build-space@v7
         with:
-          root-reserve-mb: 40960
+          root-reserve-mb: 29696
           remove-dotnet: 'true'
           remove-haskell: 'true'
           remove-android: 'true'

--- a/.github/workflows/integration-test-rock.yaml
+++ b/.github/workflows/integration-test-rock.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Maximise GH runner space
         uses: easimon/maximize-build-space@v7
         with:
-          root-reserve-mb: 40960
+          root-reserve-mb: 29696
           remove-dotnet: 'true'
           remove-haskell: 'true'
           remove-android: 'true'

--- a/.github/workflows/scan-rock.yaml
+++ b/.github/workflows/scan-rock.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Maximise GH runner space
         uses: easimon/maximize-build-space@v7
         with:
-          root-reserve-mb: 40960
+          root-reserve-mb: 29696
           remove-dotnet: 'true'
           remove-haskell: 'true'
           remove-android: 'true'


### PR DESCRIPTION
Due to a change in the GH runners storage, we cannot longer reserve more than ~30GB of storage with the easimon/maximize-build-space action, as we'd be hitting the following error:
  `fallocate: invalid length value specified`
This commit changes the value to 29696 to avoid issues.

Part of canonical/bundle-kubeflow#813