### PR TITLE
Increase trivy timeout

### DIFF
--- a/.github/workflows/scan-rock.yaml
+++ b/.github/workflows/scan-rock.yaml
@@ -54,6 +54,7 @@ jobs:
           format: 'json'
           output: 'trivy-report-${{ inputs.rock-artifact }}.json'
           ignore-unfixed: true
+          timeout: '50m0s'
 
       - name: Print vulnerabilities report
         run: cat trivy-report-${{ inputs.rock-artifact }}.json


### PR DESCRIPTION
This PR increases the Trivy timemout for scanning images from default 5 mins to 50 mins. This change is needed as some ROCKs (e.g. pytorch-cpu in this [PR](https://github.com/canonical/kubeflow-rocks/pull/79)) takes time to scan (The bigger GPU ones will take even longer). This change was tested in this [PR run](https://github.com/canonical/kubeflow-rocks/actions/runs/8356385436/job/22874673810) 