### PR TITLE
Fix skopeo in ubuntu-22.04 runner

### DIFF
--- a/.github/workflows/build-rock.yaml
+++ b/.github/workflows/build-rock.yaml
@@ -38,6 +38,11 @@ jobs:
       rock-artifact: ${{ steps.metadata.outputs.rock-artifact}}
       rock-filename: ${{ steps.metadata.outputs.rock-filename}}
     steps:
+      - name: Versions
+        id: versions
+        run: |
+          skopeo --version
+          docker version
       # Ideally we'd use self-hosted runners, but this effort is still not stable.
       # This action will remove unused software (dotnet, haskell, android libs, codeql,
       # and docker images) from the GH runner, which will liberate around 60 GB of storage

--- a/.github/workflows/build-rock.yaml
+++ b/.github/workflows/build-rock.yaml
@@ -38,9 +38,6 @@ jobs:
       rock-artifact: ${{ steps.metadata.outputs.rock-artifact}}
       rock-filename: ${{ steps.metadata.outputs.rock-filename}}
     steps:
-      - name: Versions
-        id: versions
-        run: |
       # Ideally we'd use self-hosted runners, but this effort is still not stable.
       # This action will remove unused software (dotnet, haskell, android libs, codeql,
       # and docker images) from the GH runner, which will liberate around 60 GB of storage

--- a/.github/workflows/build-rock.yaml
+++ b/.github/workflows/build-rock.yaml
@@ -41,8 +41,6 @@ jobs:
       - name: Versions
         id: versions
         run: |
-          skopeo --version
-          docker version
       # Ideally we'd use self-hosted runners, but this effort is still not stable.
       # This action will remove unused software (dotnet, haskell, android libs, codeql,
       # and docker images) from the GH runner, which will liberate around 60 GB of storage

--- a/.github/workflows/build_and_scan_rock.yaml
+++ b/.github/workflows/build_and_scan_rock.yaml
@@ -36,6 +36,11 @@ jobs:
           VERSION=$(yq eval ".version" rockcraft.yaml)
           ARCH=$(yq eval ".platforms | keys" rockcraft.yaml | awk -F ' ' '{print $2}')
           ROCK="${NAME}_${VERSION}_${ARCH}"
+          
+          # Using snaps for skopeo and docker because of this problem https://github.com/canonical/charmed-kubeflow-workflows/issues/53
+          sudo snap install skopeo --edge --devmode
+          sudo snap install docker
+          
           sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION
           echo "image=$ROCK:$VERSION" >> "$GITHUB_OUTPUT"
         working-directory: ${{ inputs.rock }}

--- a/.github/workflows/build_and_scan_rock.yaml
+++ b/.github/workflows/build_and_scan_rock.yaml
@@ -37,7 +37,6 @@ jobs:
           VERSION=$(yq eval ".version" rockcraft.yaml)
           ARCH=$(yq eval ".platforms | keys" rockcraft.yaml | awk -F ' ' '{print $2}')
           ROCK="${NAME}_${VERSION}_${ARCH}"
-          
           sudo rockcraft.skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION
           echo "image=$ROCK:$VERSION" >> "$GITHUB_OUTPUT"
         working-directory: ${{ inputs.rock }}

--- a/.github/workflows/build_and_scan_rock.yaml
+++ b/.github/workflows/build_and_scan_rock.yaml
@@ -25,6 +25,7 @@ jobs:
         run: |
           sudo snap install jq
           sudo snap install yq
+          sudo snap install rockcraft --classic --edge
       - name: Build ROCK
         uses: canonical/craft-actions/rockcraft-pack@main
         with:
@@ -37,11 +38,7 @@ jobs:
           ARCH=$(yq eval ".platforms | keys" rockcraft.yaml | awk -F ' ' '{print $2}')
           ROCK="${NAME}_${VERSION}_${ARCH}"
           
-          # Using snaps for skopeo and docker because of this problem https://github.com/canonical/charmed-kubeflow-workflows/issues/53
-          sudo snap install skopeo --edge --devmode
-          sudo snap install docker
-          
-          sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION
+          sudo rockcraft.skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION
           echo "image=$ROCK:$VERSION" >> "$GITHUB_OUTPUT"
         working-directory: ${{ inputs.rock }}
       - name: Scan for vulnerabilities

--- a/.github/workflows/integration-test-rock.yaml
+++ b/.github/workflows/integration-test-rock.yaml
@@ -81,6 +81,10 @@ jobs:
       - name: Export ROCK to Docker
         id: rock_in_docker
         run: |
+          # Using snaps for skopeo and docker because of this problem https://github.com/canonical/charmed-kubeflow-workflows/issues/53
+          sudo snap install skopeo --edge --devmode
+          sudo snap install docker
+          
           sudo skopeo --insecure-policy copy oci-archive:${{ inputs.rock-filename }} docker-daemon:${{ inputs.rock-reference }}
           echo "image=${{ inputs.rock-reference }}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/integration-test-rock.yaml
+++ b/.github/workflows/integration-test-rock.yaml
@@ -61,6 +61,9 @@ jobs:
         with:
           ref: ${{ inputs.source-branch }}
 
+      - name: Install Rockcraft
+        run: sudo snap install rockcraft --classic --edge
+
       - uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.rock-artifact }}
@@ -81,11 +84,7 @@ jobs:
       - name: Export ROCK to Docker
         id: rock_in_docker
         run: |
-          # Using snaps for skopeo and docker because of this problem https://github.com/canonical/charmed-kubeflow-workflows/issues/53
-          sudo snap install skopeo --edge --devmode
-          sudo snap install docker
-          
-          sudo skopeo --insecure-policy copy oci-archive:${{ inputs.rock-filename }} docker-daemon:${{ inputs.rock-reference }}
+          sudo rockcraft.skopeo --insecure-policy copy oci-archive:${{ inputs.rock-filename }} docker-daemon:${{ inputs.rock-reference }}
           echo "image=${{ inputs.rock-reference }}" >> "$GITHUB_OUTPUT"
 
       - name: Clean up .rock file

--- a/.github/workflows/publish-rock.yaml
+++ b/.github/workflows/publish-rock.yaml
@@ -34,6 +34,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.source-branch }}
+      
+      - name: Install Rockcraft
+        run: sudo snap install rockcraft --classic --edge
 
       - uses: actions/download-artifact@v3
         with:
@@ -51,11 +54,7 @@ jobs:
           COMMIT_ID=$(git rev-parse --short HEAD)
           DOCKER_IMAGE=${{ inputs.rock-reference }}-$COMMIT_ID
           
-          # Using snaps for skopeo and docker because of this problem https://github.com/canonical/charmed-kubeflow-workflows/issues/53
-          sudo snap install skopeo --edge --devmode
-          sudo snap install docker
-          
-          sudo skopeo --insecure-policy copy oci-archive:${{ inputs.rock-filename }} docker-daemon:${{ inputs.registry }}/$DOCKER_IMAGE
+          sudo rockcraft.skopeo --insecure-policy copy oci-archive:${{ inputs.rock-filename }} docker-daemon:${{ inputs.registry }}/$DOCKER_IMAGE
           echo "image=$DOCKER_IMAGE" >> "$GITHUB_OUTPUT"
 
       - name: Publish to dockerhub

--- a/.github/workflows/publish-rock.yaml
+++ b/.github/workflows/publish-rock.yaml
@@ -53,7 +53,6 @@ jobs:
         run: |
           COMMIT_ID=$(git rev-parse --short HEAD)
           DOCKER_IMAGE=${{ inputs.rock-reference }}-$COMMIT_ID
-          
           sudo rockcraft.skopeo --insecure-policy copy oci-archive:${{ inputs.rock-filename }} docker-daemon:${{ inputs.registry }}/$DOCKER_IMAGE
           echo "image=$DOCKER_IMAGE" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/publish-rock.yaml
+++ b/.github/workflows/publish-rock.yaml
@@ -50,6 +50,11 @@ jobs:
         run: |
           COMMIT_ID=$(git rev-parse --short HEAD)
           DOCKER_IMAGE=${{ inputs.rock-reference }}-$COMMIT_ID
+          
+          # Using snaps for skopeo and docker because of this problem https://github.com/canonical/charmed-kubeflow-workflows/issues/53
+          sudo snap install skopeo --edge --devmode
+          sudo snap install docker
+          
           sudo skopeo --insecure-policy copy oci-archive:${{ inputs.rock-filename }} docker-daemon:${{ inputs.registry }}/$DOCKER_IMAGE
           echo "image=$DOCKER_IMAGE" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/sanity-test-rock.yaml
+++ b/.github/workflows/sanity-test-rock.yaml
@@ -42,6 +42,11 @@ jobs:
       - name: Export ROCK to Docker
         id: rock_in_docker
         run: |
+          sudo snap install skopeo --edge --devmode
+          which skopeo
+          skopeo --version
+          /snap/bin/skopeo --version
+          docker version
           sudo skopeo --insecure-policy copy oci-archive:${{ inputs.rock-filename}} docker-daemon:${{ inputs.rock-reference }}
           echo "image=${{ inputs.rock-reference}}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/sanity-test-rock.yaml
+++ b/.github/workflows/sanity-test-rock.yaml
@@ -42,13 +42,10 @@ jobs:
       - name: Export ROCK to Docker
         id: rock_in_docker
         run: |
+          # Using snaps for skopeo and docker because of this problem https://github.com/canonical/charmed-kubeflow-workflows/issues/53
           sudo snap install skopeo --edge --devmode
           sudo snap install docker
-          which skopeo
-          which docker
-          skopeo --version
-          /snap/bin/skopeo --version
-          docker version
+          
           sudo skopeo --insecure-policy copy oci-archive:${{ inputs.rock-filename}} docker-daemon:${{ inputs.rock-reference }}
           echo "image=${{ inputs.rock-reference}}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/sanity-test-rock.yaml
+++ b/.github/workflows/sanity-test-rock.yaml
@@ -34,6 +34,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.source-branch }}
+      
+      - name: Install Rockcraft
+        run: sudo snap install rockcraft --classic --edge
 
       - uses: actions/download-artifact@v3
         with:
@@ -42,13 +45,7 @@ jobs:
       - name: Export ROCK to Docker
         id: rock_in_docker
         run: |
-          # Using snaps for skopeo and docker because of this problem https://github.com/canonical/charmed-kubeflow-workflows/issues/53
-          sudo snap install skopeo --edge --devmode
-          sudo snap install docker
-          which skopeo
-          which docker
-          
-          sudo skopeo --insecure-policy copy oci-archive:${{ inputs.rock-filename}} docker-daemon:${{ inputs.rock-reference }}
+          sudo rockcraft.skopeo --insecure-policy copy oci-archive:${{ inputs.rock-filename}} docker-daemon:${{ inputs.rock-reference }}
           echo "image=${{ inputs.rock-reference}}" >> "$GITHUB_OUTPUT"
 
       - name: Install tox

--- a/.github/workflows/sanity-test-rock.yaml
+++ b/.github/workflows/sanity-test-rock.yaml
@@ -45,6 +45,8 @@ jobs:
           # Using snaps for skopeo and docker because of this problem https://github.com/canonical/charmed-kubeflow-workflows/issues/53
           sudo snap install skopeo --edge --devmode
           sudo snap install docker
+          which skopeo
+          which docker
           
           sudo skopeo --insecure-policy copy oci-archive:${{ inputs.rock-filename}} docker-daemon:${{ inputs.rock-reference }}
           echo "image=${{ inputs.rock-reference}}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/sanity-test-rock.yaml
+++ b/.github/workflows/sanity-test-rock.yaml
@@ -43,7 +43,9 @@ jobs:
         id: rock_in_docker
         run: |
           sudo snap install skopeo --edge --devmode
+          sudo snap install docker
           which skopeo
+          which docker
           skopeo --version
           /snap/bin/skopeo --version
           docker version

--- a/.github/workflows/scan-rock.yaml
+++ b/.github/workflows/scan-rock.yaml
@@ -42,6 +42,10 @@ jobs:
       - name: Export ROCK to Docker
         id: rock_in_docker
         run: |
+          # Using snaps for skopeo and docker because of this problem https://github.com/canonical/charmed-kubeflow-workflows/issues/53
+          sudo snap install skopeo --edge --devmode
+          sudo snap install docker
+          
           sudo skopeo --insecure-policy copy oci-archive:${{ inputs.rock-filename }} docker-daemon:rock:tag
           echo "image=rock:tag" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/scan-rock.yaml
+++ b/.github/workflows/scan-rock.yaml
@@ -34,6 +34,9 @@ jobs:
           remove-haskell: 'true'
           remove-android: 'true'
           remove-codeql: 'true'
+      
+      - name: Install Rockcraft
+        run: sudo snap install rockcraft --classic --edge
 
       - uses: actions/download-artifact@v3
         with:
@@ -42,11 +45,7 @@ jobs:
       - name: Export ROCK to Docker
         id: rock_in_docker
         run: |
-          # Using snaps for skopeo and docker because of this problem https://github.com/canonical/charmed-kubeflow-workflows/issues/53
-          sudo snap install skopeo --edge --devmode
-          sudo snap install docker
-          
-          sudo skopeo --insecure-policy copy oci-archive:${{ inputs.rock-filename }} docker-daemon:rock:tag
+          sudo rockcraft.skopeo --insecure-policy copy oci-archive:${{ inputs.rock-filename }} docker-daemon:rock:tag
           echo "image=rock:tag" >> "$GITHUB_OUTPUT"
 
       - name: Scan for vulnerabilities


### PR DESCRIPTION
Closes: https://github.com/canonical/charmed-kubeflow-workflows/issues/53

Use rockcraft's skopeo to move the image to the Docker. More technical information is in the issue.

Test run can  be found here: https://github.com/canonical/kserve-rocks/actions/runs/9481728740/job/26166315258?pr=83