### PR TITLE
feat: Add option in TF checks to skip apply

### DIFF
--- a/.github/workflows/terraform-checks.yaml
+++ b/.github/workflows/terraform-checks.yaml
@@ -21,7 +21,7 @@ on:
         description: Boolean value that defines if `apply` job runs. Defaults to `True`.
         required: false
         type: boolean
-        default: True
+        default: true
 jobs:
   apply:
     name: Apply

--- a/.github/workflows/terraform-checks.yaml
+++ b/.github/workflows/terraform-checks.yaml
@@ -17,10 +17,16 @@ on:
         required: false
         type: string
         default: latest/stable
+      apply:
+        description: Boolean value that defines if `apply` job runs. Defaults to `True`.
+        required: false
+        type: boolean
+        default: True
 jobs:
   apply:
     name: Apply
     uses: ./.github/workflows/terraform-apply.yaml
+    if: ${{ inputs.apply }}
     with:
       model: ${{ inputs.model }}
       channel: ${{ inputs.channel }}

--- a/.github/workflows/terraform-checks.yaml
+++ b/.github/workflows/terraform-checks.yaml
@@ -18,7 +18,7 @@ on:
         type: string
         default: latest/stable
       apply:
-        description: Boolean value that defines if `apply` job runs. Defaults to `True`.
+        description: Boolean value that defines if `apply` job runs. Defaults to `true`.
         required: false
         type: boolean
         default: true


### PR DESCRIPTION
Since `apply` job may fail due to some charms having dependency, this PR makes it optional. Right now, our Terraform CI and tests story is immature. In the future, we will probably move away from those workflows, since the Terraform Charming WG is going to provide us with the required workflows, while also the testing story will be more defined.

Fixes #63