### PR TITLE
ci: add workflow to enable automatic vulnerability reports

### DIFF
--- a/.github/workflows/report-vulnerability-in-gh.yaml
+++ b/.github/workflows/report-vulnerability-in-gh.yaml
@@ -31,6 +31,12 @@ jobs:
           sudo snap install gh
           sudo snap install jq
 
+      - name: Generate image name for title
+        id: image-title
+        run:
+          IMAGE_TITLE=$(echo ${{ inputs.image-name }} | rev | cut -f2- -d'-' | rev)
+          echo "image-title=$IMAGE_TITLE" >> $GITHUB_OUTPUT
+
       - name: Get issue number if exists
         id: get-issue-number
         run: |
@@ -44,12 +50,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.vulnerability-report-artefact }}
-
-      - name: Generate image name for title
-        id: image-title
-        run:
-          IMAGE_TITLE=$(echo ${{ inputs.image-name }} | rev | cut -f2- -d'-' | rev)
-          echo "image-title=$IMAGE_TITLE" >> $GITHUB_OUTPUT
 
       - name: Issue body
         id: issue-body

--- a/.github/workflows/report-vulnerability-in-gh.yaml
+++ b/.github/workflows/report-vulnerability-in-gh.yaml
@@ -13,7 +13,7 @@ on:
         default: "bug"
       image-name:
         description: "Name of the oci-image as saved in Dockerhub or in the docker cache.
-          It consists of <rock-name>:<rock-version>."
+          It consists of <image-name>:<tag>."
         required: true
         type: string
       vulnerability-report-artefact:
@@ -35,7 +35,8 @@ jobs:
         id: get-issue-number
         run: |
           export GH_TOKEN=${{ secrets.GH_TOKEN }}
-          EXPECTED_TITLE=$(echo "${{ inputs.issue-title }} ${{ inputs.image-name }}")
+          # The expected title has to be kept consistent across all runs so the issue can be found/edit
+          EXPECTED_TITLE=$(echo "${{ inputs.issue-title }} ${{ steps.image-title.outputs.image-title }}")
           ISSUE_NUMBER=$(gh issue list --repo $GITHUB_REPOSITORY --limit 500 --json "number,title" | jq -r --arg expected_title "$EXPECTED_TITLE" '.[] | select(.title == $expected_title) | .number')
           echo "issue-number=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
 
@@ -44,11 +45,17 @@ jobs:
         with:
           name: ${{ inputs.vulnerability-report-artefact }}
 
+      - name: Generate image name for title
+        id: image-title
+        run:
+          IMAGE_TITLE=$(echo ${{ inputs.image-name }} | rev | cut -f2- -d'-' | rev)
+          echo "image-title=$IMAGE_TITLE" >> $GITHUB_OUTPUT
+
       - name: Issue body
         id: issue-body
         run: |
           set -xeu
-          EXPECTED_TITLE=$(echo "${{ inputs.issue-title }} ${{ inputs.image-name }}")
+          EXPECTED_TITLE=$(echo "${{ inputs.issue-title }} ${{ steps.image-title.outputs.image-title }}")
           echo "## $EXPECTED_TITLE" > issue.md
           echo "" >> issue.md
           echo "\`\`\`" >> issue.md
@@ -61,7 +68,7 @@ jobs:
       - name: Report failures via Github issue
         run: |
           export GH_TOKEN=${{ secrets.GH_TOKEN }}
-          EXPECTED_TITLE=$(echo "${{ inputs.issue-title }} ${{ inputs.image-name }}")
+          EXPECTED_TITLE=$(echo "${{ inputs.issue-title }} ${{ steps.image-title.outputs.image-title }}")
           if [ -z ${{ steps.get-issue-number.outputs.issue-number }} ]; then
             echo "---- Creating issue ----"
             gh issue create --repo $GITHUB_REPOSITORY \

--- a/.github/workflows/report-vulnerability-in-gh.yaml
+++ b/.github/workflows/report-vulnerability-in-gh.yaml
@@ -31,12 +31,6 @@ jobs:
           sudo snap install gh
           sudo snap install jq
 
-      - name: Generate image name
-        id: image-name
-        run: |
-          IMAGE_NAME=$(echo ${{ inputs.image-name }} | sed 's/\:/-/g')
-          echo "image-name=${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
-
       - name: Get issue number if exists
         id: get-issue-number
         run: |

--- a/.github/workflows/report-vulnerability-in-gh.yaml
+++ b/.github/workflows/report-vulnerability-in-gh.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Generate image name for title
         id: image-title
-        run:
+        run: |
           IMAGE_TITLE=$(echo ${{ inputs.image-name }} | rev | cut -f2- -d'-' | rev)
           echo "image-title=$IMAGE_TITLE" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/report-vulnerability-in-gh.yaml
+++ b/.github/workflows/report-vulnerability-in-gh.yaml
@@ -1,0 +1,78 @@
+name: Report vulnerability issues in Github
+on:
+  workflow_call:
+    inputs:
+      issue-title:
+        description: The title of the issue to be created/edited
+        required: true
+        type: string
+      issue-labels:
+        description: A comma separated list of labels
+        required: false
+        type: string
+        default: "bug"
+      image-name:
+        description: "Name of the oci-image as saved in Dockerhub or in the docker cache.
+          It consists of <rock-name>:<rock-version>."
+        required: true
+        type: string
+
+jobs:
+  report-vulns:
+    name: Create or edit issues for reporting vulnerabilities
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Install tools
+        run: |
+          sudo snap install gh
+          sudo snap install jq
+
+      - name: Generate image name
+        id: image-name
+        run: |
+          IMAGE_NAME=$(echo ${{ inputs.image-name }} | sed 's/\:/-/g')
+          echo "image-name=${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Get issue number if exists
+        id: get-issue-number
+        run: |
+          export GH_TOKEN=${{ secrets.GH_TOKEN }}
+          EXPECTED_TITLE=$(echo "${{ inputs.issue-title }} ${{ inputs.image-name }}")
+          ISSUE_NUMBER=$(gh issue list --repo $GITHUB_REPOSITORY --limit 500 --json "number,title" | jq -r --arg expected_title "$EXPECTED_TITLE" '.[] | select(.title == $expected_title) | .number')
+          echo "issue-number=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
+
+      - name: Download report
+        uses: actions/download-artifact@v4
+        with:
+          name: trivy-report-${{ steps.image-name.outputs.image-name }}
+
+      - name: Issue body
+        id: issue-body
+        run: |
+          set -xeu
+          EXPECTED_TITLE=$(echo "${{ inputs.issue-title }} ${{ inputs.image-name }}")
+          echo "## $EXPECTED_TITLE" > issue.md
+          echo "" >> issue.md
+          echo "\`\`\`" >> issue.md
+          cat trivy-report-${{ steps.image-name.outputs.image-name }}.txt >> issue.md
+          echo "\`\`\`" >> issue.md
+          echo "" >> issue.md
+          echo -e "\nDetails: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> issue.md
+          echo "issue-body-file=issue.md" >> "$GITHUB_OUTPUT"
+
+      - name: Report failures via Github issue
+        run: |
+          export GH_TOKEN=${{ secrets.GH_TOKEN }}
+          EXPECTED_TITLE=$(echo "${{ inputs.issue-title }} ${{ inputs.image-name }}")
+          if [ -z ${{ steps.get-issue-number.outputs.issue-number }} ]; then
+            echo "---- Creating issue ----"
+            gh issue create --repo $GITHUB_REPOSITORY \
+            --title "$EXPECTED_TITLE" \
+            --label "${{ inputs.issue-labels }}" \
+            --body-file "${{ steps.issue-body.outputs.issue-body-file }}"
+          else
+            echo "---- Editing issue ${{ steps.get-issue-number.outputs.issue-number }}----"
+            gh issue edit --repo $GITHUB_REPOSITORY ${{ steps.get-issue-number.outputs.issue-number }} \
+            --title "$EXPECTED_TITLE" \
+            --body-file "${{ steps.issue-body.outputs.issue-body-file }}"
+          fi

--- a/.github/workflows/report-vulnerability-in-gh.yaml
+++ b/.github/workflows/report-vulnerability-in-gh.yaml
@@ -16,10 +16,14 @@ on:
           It consists of <rock-name>:<rock-version>."
         required: true
         type: string
+      vulnerability-response-artefact:
+        description: "The artefact name of the uploaded trivy report. Used to render the issue body."
+        required: true
+        type: string
 
 jobs:
   report-vulns:
-    name: Create or edit issues for reporting vulnerabilities
+    name: Report vulerabilities in Github
     runs-on: ubuntu-22.04
     steps:
       - name: Install tools
@@ -44,7 +48,7 @@ jobs:
       - name: Download report
         uses: actions/download-artifact@v4
         with:
-          name: trivy-report-${{ steps.image-name.outputs.image-name }}
+          name: ${{ inputs.vulnerability-response-artefact }}
 
       - name: Issue body
         id: issue-body
@@ -54,7 +58,7 @@ jobs:
           echo "## $EXPECTED_TITLE" > issue.md
           echo "" >> issue.md
           echo "\`\`\`" >> issue.md
-          cat trivy-report-${{ steps.image-name.outputs.image-name }}.txt >> issue.md
+          cat ${{ inputs.vulnerability-response-artefact }}.txt >> issue.md
           echo "\`\`\`" >> issue.md
           echo "" >> issue.md
           echo -e "\nDetails: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> issue.md

--- a/.github/workflows/report-vulnerability-in-gh.yaml
+++ b/.github/workflows/report-vulnerability-in-gh.yaml
@@ -16,7 +16,7 @@ on:
           It consists of <rock-name>:<rock-version>."
         required: true
         type: string
-      vulnerability-response-artefact:
+      vulnerability-report-artefact:
         description: "The artefact name of the uploaded trivy report. Used to render the issue body."
         required: true
         type: string
@@ -42,7 +42,7 @@ jobs:
       - name: Download report
         uses: actions/download-artifact@v4
         with:
-          name: ${{ inputs.vulnerability-response-artefact }}
+          name: ${{ inputs.vulnerability-report-artefact }}
 
       - name: Issue body
         id: issue-body
@@ -52,7 +52,7 @@ jobs:
           echo "## $EXPECTED_TITLE" > issue.md
           echo "" >> issue.md
           echo "\`\`\`" >> issue.md
-          cat ${{ inputs.vulnerability-response-artefact }}.txt >> issue.md
+          cat ${{ inputs.vulnerability-report-artefact }}.txt >> issue.md
           echo "\`\`\`" >> issue.md
           echo "" >> issue.md
           echo -e "\nDetails: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> issue.md


### PR DESCRIPTION
This re-usable workflow can be used for reporting security vulnerabilities via Github issues. It takes the issue title, image-name, and issue-labels as inputs, and in turn:
* edits an existing issue with the same title and updates the vulnerability report
* creates a new issue with the issue-title and adds the vulnerability report in the description

Please NOTE this workflow assumes the existence of vulnerability reports as artefacts of a workflow run; that is, it expects artefacts named trivy-report-<image-name> to be present in the sabe workflow run.

Part of #69

#### For reviewers

This workflow has been tested in [this fork](https://github.com/DnPlas/kubeflow-rocks). The re-usable workflow is capable of generating [these](https://github.com/DnPlas/kubeflow-rocks/issues) type of issues. Please note how they are edited if the `Scan images` workflow is run multiple times.
The workflow that generated those can be found [here](https://github.com/DnPlas/kubeflow-rocks/blob/main/.github/workflows/scan_images.yaml), and the re-usable workflow that is mentioned there is fully implemented in https://github.com/canonical/charmed-kubeflow-workflows/pull/73.