### PR TITLE
feat: report vulnerabilities as GH issues and scan images from registry 

### DIFF
--- a/.github/workflows/_bundle.yaml
+++ b/.github/workflows/_bundle.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@1.1.0
         with:

--- a/.github/workflows/_integration-tests.yaml
+++ b/.github/workflows/_integration-tests.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Integration tests
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@1.1.0
         with:

--- a/.github/workflows/_observability.yaml
+++ b/.github/workflows/_observability.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@1.1.0

--- a/.github/workflows/_publish.yaml
+++ b/.github/workflows/_publish.yaml
@@ -35,7 +35,7 @@ jobs:
     outputs:
       charm_paths: ${{ steps.get-charm-paths.outputs.charm-paths }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with: 
           fetch-depth: 0
       - name: Get paths for all charms in this repo
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ inputs.source_branch }}

--- a/.github/workflows/_quality-checks.yaml
+++ b/.github/workflows/_quality-checks.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Check libs
@@ -27,6 +27,6 @@ jobs:
     name: Lint
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: python3 -m pip install tox
       - run: tox -c ${{ inputs.charm-path }} -e lint

--- a/.github/workflows/_unit-tests.yaml
+++ b/.github/workflows/_unit-tests.yaml
@@ -13,6 +13,6 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: python3 -m pip install tox
       - run: tox -e ${{ inputs.charm-name }}-unit

--- a/.github/workflows/build-rock.yaml
+++ b/.github/workflows/build-rock.yaml
@@ -74,7 +74,7 @@ jobs:
           echo "rock-filename=$ROCK" >> "$GITHUB_OUTPUT"
         working-directory: ${{ inputs.rock-dir }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.metadata.outputs.rock-artifact }}
           path: ${{ inputs.rock-dir }}/${{ steps.metadata.outputs.rock-filename }}

--- a/.github/workflows/build_and_scan_rock.yaml
+++ b/.github/workflows/build_and_scan_rock.yaml
@@ -18,7 +18,7 @@ jobs:
     name: Build and scan ROCK
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install tools
@@ -68,7 +68,7 @@ jobs:
           tar zcvf trivy-report-${{ inputs.rock }}.tar.gz trivy-report-${{ inputs.rock }}.json
         working-directory: ${{ inputs.rock }}
       - name: Upload Trivy reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: trivy-report-${{ inputs.rock }}
           path: ${{ inputs.rock }}/trivy-report-${{ inputs.rock }}.tar.gz

--- a/.github/workflows/contributing_update_all.yaml
+++ b/.github/workflows/contributing_update_all.yaml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       charm_paths: ${{ steps.get-charm-paths.outputs.charm-paths }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Get paths for all charms in this repo

--- a/.github/workflows/get-image-names-from-rockcraft.yaml
+++ b/.github/workflows/get-image-names-from-rockcraft.yaml
@@ -1,0 +1,46 @@
+name: Get oci-images names from rockcraft files
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        required: false
+        type: string
+    outputs:
+      images-names:
+        description: "A JSON array of all images that have their rockcraft project stored in this repository"
+        value: ${{ jobs.get-images-names.outputs.images-names }}
+
+jobs:
+  get-images-names:
+    name: Get image names
+    runs-on: ubuntu-22.04
+    outputs:
+      images-names: ${{ steps.get-images.outputs.images-names }}
+    steps:
+      - name: Checkout repository code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.branch }}
+
+      - name: Install tools
+        run: |
+          sudo snap install yq
+          sudo apt install jq
+
+      - name: Get images names
+        id: get-images
+        run: |
+          set -xeu
+          IMAGES_NAMES=()
+          paths=$(find ./ -name "rockcraft.yaml" | sed 's/\.\///g')
+          for d in $paths
+          do
+            short_hash=$(git log -n 1 --pretty=%h -- ${d})
+            image_name=$(cat ${d} | yq -r '.name')
+            image_version=$(cat ${d} | yq -r '.version')
+            IMAGES_NAMES+=(${image_name}:${image_version}-${short_hash})
+          done
+          IMAGES_ARRAY=$(jq -c -n '$ARGS.positional' --args "${IMAGES_NAMES[@]}")
+          echo "images-names=${IMAGES_ARRAY}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/get-published-images-scan-and-report.yaml
+++ b/.github/workflows/get-published-images-scan-and-report.yaml
@@ -1,0 +1,36 @@
+name: Get image names and report vulnerabilties in Github
+
+on:
+  workflow_call:
+    secrets:
+      GH_TOKEN:
+        required: true
+    inputs:
+      severity:
+        description: "Comma separated list of severities of vulnerabilities to scanned for and displayed"
+        required: false
+        type: string
+        default: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
+      branch:
+        required: false
+        type: string
+
+jobs:
+  get-published-images-names:
+    name: Get images names from rockcraft
+    uses: ./.github/workflows/get-image-names-from-rockcraft.yaml
+    with:
+      branch: ${{ inputs.branch }}
+
+  scan-report-vulnerability:
+    needs: get-published-images-names
+    name: Scan and report
+    strategy:
+      fail-fast: false
+      matrix:
+        image-name: ${{ fromJson(needs.get-published-images-names.outputs.images-names) }}
+    uses: ./.github/workflows/scan-from-dockerhub-report-issue.yaml
+    secrets: inherit
+    with:
+      image-name: ${{ matrix.image-name }}
+      severity: ${{ inputs.severity }}

--- a/.github/workflows/get-rocks-modified.yaml
+++ b/.github/workflows/get-rocks-modified.yaml
@@ -15,7 +15,7 @@ jobs:
       paths: ${{ steps.find.outputs.paths}}
     steps:
       - name: Checkout repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Get all rockcraft.yaml paths using find
         id: find
         run: |
@@ -37,7 +37,7 @@ jobs:
       rock_paths: ${{ steps.filter.outputs.changes }}
     steps:
       - name: Checkout repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: dorny/paths-filter@v2
         id: filter
         with:

--- a/.github/workflows/integration-test-rock.yaml
+++ b/.github/workflows/integration-test-rock.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Install Rockcraft
         run: sudo snap install rockcraft --classic --edge
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.rock-artifact }}
 
@@ -142,7 +142,7 @@ jobs:
 
       - name: Upload debug artifacts
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-run-artifacts
           path: tmp

--- a/.github/workflows/publish-rock.yaml
+++ b/.github/workflows/publish-rock.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Rockcraft
         run: sudo snap install rockcraft --classic --edge
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.rock-artifact }}
 

--- a/.github/workflows/report-vulnerability-in-gh.yaml
+++ b/.github/workflows/report-vulnerability-in-gh.yaml
@@ -1,0 +1,83 @@
+name: Report vulnerability issues in Github
+on:
+  workflow_call:
+    inputs:
+      issue-title:
+        description: The title of the issue to be created/edited
+        required: true
+        type: string
+      issue-labels:
+        description: A comma separated list of labels
+        required: false
+        type: string
+        default: "bug"
+      image-name:
+        description: "Name of the oci-image as saved in Dockerhub or in the docker cache.
+          It consists of <image-name>:<tag>."
+        required: true
+        type: string
+      vulnerability-report-artefact:
+        description: "The artefact name of the uploaded trivy report. Used to render the issue body."
+        required: true
+        type: string
+
+jobs:
+  report-vulns:
+    name: Report vulerabilities in Github
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Install tools
+        run: |
+          sudo snap install gh
+          sudo snap install jq
+
+      - name: Generate image name for title
+        id: image-title
+        run: |
+          IMAGE_TITLE=$(echo ${{ inputs.image-name }} | rev | cut -f2- -d'-' | rev)
+          echo "image-title=$IMAGE_TITLE" >> $GITHUB_OUTPUT
+
+      - name: Get issue number if exists
+        id: get-issue-number
+        run: |
+          export GH_TOKEN=${{ secrets.GH_TOKEN }}
+          # The expected title has to be kept consistent across all runs so the issue can be found/edit
+          EXPECTED_TITLE=$(echo "${{ inputs.issue-title }} ${{ steps.image-title.outputs.image-title }}")
+          ISSUE_NUMBER=$(gh issue list --repo $GITHUB_REPOSITORY --limit 500 --json "number,title" | jq -r --arg expected_title "$EXPECTED_TITLE" '.[] | select(.title == $expected_title) | .number')
+          echo "issue-number=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
+
+      - name: Download report
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.vulnerability-report-artefact }}
+
+      - name: Issue body
+        id: issue-body
+        run: |
+          set -xeu
+          EXPECTED_TITLE=$(echo "${{ inputs.issue-title }} ${{ steps.image-title.outputs.image-title }}")
+          echo "## $EXPECTED_TITLE" > issue.md
+          echo "" >> issue.md
+          echo "\`\`\`" >> issue.md
+          cat ${{ inputs.vulnerability-report-artefact }}.txt >> issue.md
+          echo "\`\`\`" >> issue.md
+          echo "" >> issue.md
+          echo -e "\nDetails: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> issue.md
+          echo "issue-body-file=issue.md" >> "$GITHUB_OUTPUT"
+
+      - name: Report failures via Github issue
+        run: |
+          export GH_TOKEN=${{ secrets.GH_TOKEN }}
+          EXPECTED_TITLE=$(echo "${{ inputs.issue-title }} ${{ steps.image-title.outputs.image-title }}")
+          if [ -z ${{ steps.get-issue-number.outputs.issue-number }} ]; then
+            echo "---- Creating issue ----"
+            gh issue create --repo $GITHUB_REPOSITORY \
+            --title "$EXPECTED_TITLE" \
+            --label "${{ inputs.issue-labels }}" \
+            --body-file "${{ steps.issue-body.outputs.issue-body-file }}"
+          else
+            echo "---- Editing issue ${{ steps.get-issue-number.outputs.issue-number }}----"
+            gh issue edit --repo $GITHUB_REPOSITORY ${{ steps.get-issue-number.outputs.issue-number }} \
+            --title "$EXPECTED_TITLE" \
+            --body-file "${{ steps.issue-body.outputs.issue-body-file }}"
+          fi

--- a/.github/workflows/sanity-test-rock.yaml
+++ b/.github/workflows/sanity-test-rock.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Rockcraft
         run: sudo snap install rockcraft --classic --edge
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.rock-artifact }}
 

--- a/.github/workflows/scan-from-dockerhub-report-issue.yaml
+++ b/.github/workflows/scan-from-dockerhub-report-issue.yaml
@@ -1,0 +1,31 @@
+name: Scan published image and report vulnerabilities
+
+on:
+  workflow_call:
+    inputs:
+      image-name:
+        description: "The published image name to be scanned."
+        required: true
+        type: string
+      severity:
+        description: "Comma separated list of severities of vulnerabilities to scanned for and displayed"
+        required: false
+        type: string
+        default: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
+jobs:
+  scan:
+    uses: ./.github/workflows/scan-from-published-image.yaml
+    secrets: inherit
+    with:
+      image-name: ${{ inputs.image-name }}
+      severity: ${{ inputs.severity }}
+
+  report-vulnerability:
+    needs: scan
+    uses: ./.github/workflows/report-vulnerability-in-gh.yaml
+    secrets: inherit
+    if: ${{ always() && (needs.scan.result == 'failure') }}
+    with:
+      issue-title: 'Vulnerabilities found for'
+      image-name: ${{ inputs.image-name }}
+      vulnerability-report-artefact: ${{ needs.scan.outputs.vulnerability-report-artefact-name }}

--- a/.github/workflows/scan-from-published-image.yaml
+++ b/.github/workflows/scan-from-published-image.yaml
@@ -1,0 +1,89 @@
+name: Scan
+
+on:
+  workflow_call:
+    outputs:
+      vulnerability-report-artefact-name:
+        description: "The name of the artefact that contains the vulnerability report."
+        value: ${{ jobs.scan.outputs.vulnerability-report-artefact-name }}
+    inputs:
+      container-registry:
+        description: "The name of the container registry where images are hosted."
+        required: false
+        type: string
+        default: "charmedkubeflow"
+      image-name:
+        description: "The published image name to be scanned."
+        required: true
+        type: string
+      severity:
+        description: "Comma separated list of severities of vulnerabilities to scanned for and displayed"
+        required: false
+        type: string
+        default: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
+jobs:
+  scan:
+    name: Scan of ${{ inputs.image-name }}
+    runs-on: ubuntu-22.04
+    outputs:
+      vulnerability-report-artefact-name: ${{ steps.report-name.outputs.report-name }}
+    strategy:
+      fail-fast: false
+    steps:
+      # Ideally we'd use self-hosted runners, but this effort is still not stable.
+      # This action will remove unused software (dotnet, haskell, android libs, codeql,
+      # and docker images) from the GH runner, which will liberate around 60 GB of storage
+      # distributed in 40GB for root and around 20 for a mnt point.
+      # We need it to avoid cases where scanning fails due to "no space left on device".
+      - name: Maximise GH runner space
+        uses: easimon/maximize-build-space@v7
+        with:
+          root-reserve-mb: 29696
+          remove-dotnet: 'true'
+          remove-haskell: 'true'
+          remove-android: 'true'
+          remove-codeql: 'true'
+
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Generate report name
+        id: report-name
+        run: |
+          IMAGE_NAME=$(echo ${{ inputs.image-name }} | rev | cut -f2- -d"-" | rev)
+          IMAGE_NAME_DASHES=$(echo $IMAGE_NAME | sed 's/\:/-/g')
+          echo "report-name=trivy-report-${IMAGE_NAME_DASHES}" >> "$GITHUB_OUTPUT"
+
+      - name: Scan for vulnerabilities
+        id: scan
+        uses: aquasecurity/trivy-action@0.25.0
+        # Workaround for https://github.com/aquasecurity/trivy-action/issues/389
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
+        with:
+          scan-type: 'image'
+          image-ref: '${{ inputs.container-registry }}/${{ inputs.image-name }}'
+          format: 'table'
+          output: '${{ steps.report-name.outputs.report-name }}.txt'
+          ignore-unfixed: true
+          timeout: '50m0s'
+          exit-code: 1
+          severity: ${{ inputs.severity }}
+          # NOTE: pebble is flagged with a HIGH vuln because of golang.org/x/crypto
+          # CVE-2021-43565, CVE-2022-27191
+          skip-files: '/bin/pebble,/usr/bin/pebble,usr/bin/pebble,bin/pebble'
+
+      - name: Print vulnerabilities report
+        # The report should be printed regardless of the success of the previous step
+        if: success() || failure()
+        run: cat ${{ steps.report-name.outputs.report-name }}.txt
+
+      - name: Upload Trivy reports
+        # The report should be uploaded regardless of the success of the previous steps
+        if: success() || failure()
+        uses: actions/upload-artifact@v4
+        with:
+          compression-level: 0
+          name: ${{ steps.report-name.outputs.report-name }}
+          path: ${{ steps.report-name.outputs.report-name }}.txt

--- a/.github/workflows/scan-rock.yaml
+++ b/.github/workflows/scan-rock.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Rockcraft
         run: sudo snap install rockcraft --classic --edge
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.rock-artifact }}
 
@@ -63,7 +63,7 @@ jobs:
         run: cat trivy-report-${{ inputs.rock-artifact }}.json
 
       - name: Upload Trivy reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: trivy-report-${{ inputs.rock-artifact }}
           path: trivy-report-${{ inputs.rock-artifact }}.json

--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:

--- a/.github/workflows/terraform-checks.yaml
+++ b/.github/workflows/terraform-checks.yaml
@@ -42,7 +42,7 @@ jobs:
     name: Lint Terraform
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup TFLint
         uses: terraform-linters/setup-tflint@v4
       - run: python3 -m pip install tox


### PR DESCRIPTION
This PR brings all the changes from `KF-6331-dev-branch` into `main`.

* ci: add re-usable workflow for scans from published img and automatic… (https://github.com/canonical/charmed-kubeflow-workflows/pull/73)

This commit adds get-published-images-scan-and-report.yaml, a re-usable workflow
that enables repositories to scan images from a public registry (in the case
of the Analytics team it defaults to charmedkubeflow) and reports back
the security vulnerabilities as Github issues.
This workflow is intended to be used on demand (using a workflow dispatch)
and on schedule, as it will be used for continuous testing of the published
images a rock repository generates.

* ci: add workflow to enable automatic vulnerability reports (https://github.com/canonical/charmed-kubeflow-workflows/pull/72)

This re-usable workflow can be used for reporting security vulnerabilities
via Github issues. It takes the issue title, image-name, and issue-labels as
inputs, and in turn:
* edits an existing issue with the same title and updates the vulnerability report
* creates a new issue with the issue-title and adds the vulnerability report in the description

Please NOTE this workflow assumes the existence of vulnerability reports as artefacts
of a workflow run; that is, it expects artefacts named trivy-report-<image-name> to
be present in the sabe workflow run.

* chore, ci: bump artifact download/upload and checkout actions v3 -> v4 (https://github.com/canonical/charmed-kubeflow-workflows/pull/71)

Bump the version of this actions to be up to date with the latest.

All changes have been tested individually in their respective PRs.