### PR TITLE
fix: add a workaround for TOOMANYREQUESTS issue with trivy scanner

### DIFF
--- a/.github/workflows/scan-rock.yaml
+++ b/.github/workflows/scan-rock.yaml
@@ -51,6 +51,10 @@ jobs:
       - name: Scan for vulnerabilities
         id: scan
         uses: aquasecurity/trivy-action@master
+        # Workaround for https://github.com/aquasecurity/trivy-action/issues/389
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
         with:
           scan-type: 'image'
           image-ref: '${{ steps.rock_in_docker.outputs.image }}'


### PR DESCRIPTION
This commit mitigates aquasecurity/trivy-action#389, by passing ecr registries to the TRIVY_DB_REPOSITORY and TRIVY_JAVA_DB_REPOSITORY to avoid hitting request limits.