### PR TITLE
refactor: use latest change from directory for generating image tag

### DIFF
--- a/.github/workflows/get-image-names-from-rockcraft.yaml
+++ b/.github/workflows/get-image-names-from-rockcraft.yaml
@@ -34,12 +34,12 @@ jobs:
         run: |
           set -xeu
           IMAGES_NAMES=()
-          paths=$(find ./ -name "rockcraft.yaml" | sed 's/\.\///g')
+          paths=$(find ./ -name "rockcraft.yaml")
           for d in $paths
           do
-            short_hash=$(git log -n 1 --pretty=%h -- ${d})
-            image_name=$(cat ${d} | yq -r '.name')
-            image_version=$(cat ${d} | yq -r '.version')
+            short_hash=$(git log -n 1 --pretty=%h -- $(dirname ${d}))
+            image_name=$(yq -r '.name' ${d})
+            image_version=$(yq -r '.version' ${d})
             IMAGES_NAMES+=(${image_name}:${image_version}-${short_hash})
           done
           IMAGES_ARRAY=$(jq -c -n '$ARGS.positional' --args "${IMAGES_NAMES[@]}")


### PR DESCRIPTION
The actual behaviour of the rock repositories is to check for changes in the directory where a rockcraft.yaml file lives; for any changes detected, the container image will be published. The get-image-names-from-rockcraft.yaml should also follow that pattern for correctly generating the tags of the container images that will eventually be scanned.

#### Testing instructions

Manually test the bash code in a multi-rock and single-rock repos and confirm the generated image tags are correct. For example:

###### Multi-rock repo

```bash
ubuntu@charm-dev-jammy:~/kubeflow-rocks$ pwd
/home/ubuntu/kubeflow-rocks

ubuntu@charm-dev-jammy:~/kubeflow-rocks$ git branch
* main

# Execute from the root of that repo 
IMAGES_NAMES=()
          paths=$(find ./ -name "rockcraft.yaml")
          for d in $paths
          do
            short_hash=$(git log -n 1 --pretty=%h -- $(dirname ${d}))
            image_name=$(yq -r '.name' ${d})
            image_version=$(yq -r '.version' ${d})
            IMAGES_NAMES+=(${image_name}:${image_version}-${short_hash})
          done
          IMAGES_ARRAY=$(jq -c -n '$ARGS.positional' --args "${IMAGES_NAMES[@]}")
echo $IMAGES_ARRAY
["tensorboard-controller:1.9.0-d74bfd2","volumes-web-app:1.9.0-287d9e9","profile-controller:1.9.0-9e28e0c","jupyter-tensorflow-full:v1.7.0_20.04_1-5a3d6ea","jupyter-scipy:v1.8.0_20.04_1-5a3d6ea","jupyter-tensorflow-cude-full:v1.7.0_20.04_1-5a3d6ea","centraldashboard:1.9.0-385a9c5","jupyter-pytorch-full:1.8.0-5a3d6ea","jupyter-web-app:1.9.0-2920db1","jupyter-pytorch-cuda-full:v1.8.0_20.04_1-5a3d6ea","tensorboards-web-app:1.9.0-4b44bb5","kfam:1.9.0-afd96fb","admission-webhook:v1.9.0-b041e5f","notebook-controller:1.9.0-249e99c"]
```

Check the tags correspond to the latest published images in the [charmedkubeflow Docker registry](https://hub.docker.com/r/charmedkubeflow) and they also correspond to the latest commit hash in the repo.

###### Single-rock repo

```bash
ubuntu@charm-dev-jammy:~/training-operator-rock$ pwd
/home/ubuntu/training-operator-rock

ubuntu@charm-dev-jammy:~/training-operator-rock$ git branch
* main

# Execute from the root of that repo 
IMAGES_NAMES=()
          paths=$(find ./ -name "rockcraft.yaml")
          for d in $paths
          do
            short_hash=$(git log -n 1 --pretty=%h -- $(dirname ${d}))
            image_name=$(yq -r '.name' ${d})
            image_version=$(yq -r '.version' ${d})
            IMAGES_NAMES+=(${image_name}:${image_version}-${short_hash})
          done
          IMAGES_ARRAY=$(jq -c -n '$ARGS.positional' --args "${IMAGES_NAMES[@]}")
echo $IMAGES_ARRAY
["training-operator:1.8.0-9fc20fd"]
```

Check the tags correspond to the latest published images in the [charmedkubeflow Docker registry](https://hub.docker.com/r/charmedkubeflow) and they also correspond to the latest commit hash in the repo.