### PR TITLE
ci: bump build_charm.yaml 21.0.0 -> 24.0.5

### DIFF
--- a/.github/workflows/get_charms_build_with_cache.yaml
+++ b/.github/workflows/get_charms_build_with_cache.yaml
@@ -20,7 +20,7 @@ jobs:
 
   build:
     name: Build charms
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v21.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v24.0.5
     needs: get-charm-paths
     strategy:
       fail-fast: false


### PR DESCRIPTION
This will bring a fix for the runner requesting a password when adding the runner user to the LXD group.

Fixes #89

https://github.com/canonical/kfp-operators/pull/640 is an example of how this is fixed.