### PR TITLE
use charmcraft channel 3.x/edge for check libs

### DIFF
--- a/.github/workflows/_quality-checks.yaml
+++ b/.github/workflows/_quality-checks.yaml
@@ -22,6 +22,7 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           charm-path: "${{ inputs.charm-path }}"
+          charmcraft-channel: 3.x/edge # TODO: remove after charmcraft 3.3 stable release
 
   lint:
     name: Lint


### PR DESCRIPTION
This PR temporarily changes the channel of charmcraft used in check-libs action to `3.x/edge`, by default it uses `latest/stable` which currently does not support `platforms` syntax. It is needed to verify the check libs on the `platforms` syntax used in https://github.com/canonical/kfp-operators/pull/648.