### PR TITLE
fix(ci): Check unit's status in terraform apply workflow

### DIFF
--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -49,6 +49,7 @@ jobs:
           terraform apply -var "channel=${{ inputs.channel }}" -var "model_name=${{ inputs.model }}" --auto-approve
       - name: Wait for the application to be active or blocked
         run: |
+          # Check status of the unit instead of application due to https://github.com/juju/juju/issues/18625
           juju wait-for model ${{ inputs.model }} --query="forEach(units, unit => (unit.workload-status == 'active' || unit.workload-status == 'blocked'))"
       - name: Juju status
         run: juju status

--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -49,7 +49,7 @@ jobs:
           terraform apply -var "channel=${{ inputs.channel }}" -var "model_name=${{ inputs.model }}" --auto-approve
       - name: Wait for the application to be active or blocked
         run: |
-          juju wait-for model ${{ inputs.model }} --query='forEach(applications, app => (app.status == "active" || app.status == "blocked") )'
+          juju wait-for model ${{ inputs.model }} --query="forEach(units, unit => (unit.workload-status == 'active' || unit.workload-status == 'blocked'))"
       - name: Juju status
         run: juju status
       - name: Dump logs


### PR DESCRIPTION
Check for unit's status instead of application in order to work around juju/juju#18625

Closes #92

#### Testing
* See issue for a bit of more details on the issue.
* See linked PRs that confirm run the workflow from this branch.