### PR TITLE
chore: use charmcraft latest/candidate for check libs

### DIFF
--- a/.github/workflows/_quality-checks.yaml
+++ b/.github/workflows/_quality-checks.yaml
@@ -22,6 +22,7 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           charm-path: "${{ inputs.charm-path }}"
+          charmcraft-channel: latest/candidate # TODO: remove after charmcraft 3.3 stable release
 
   lint:
     name: Lint


### PR DESCRIPTION
This PR temporarily changes the channel of charmcraft used in check-libs action to `latest/candidate`, by default it uses latest/stable which currently does not support platforms syntax. It is needed to work on the charmcraft.yaml `ST124` changes, for example https://github.com/canonical/kubeflow-tensorboards-operator/issues/154.