### PR TITLE
Remove charmcraft pin in quality checks workflow

### DIFF
--- a/.github/workflows/_quality-checks.yaml
+++ b/.github/workflows/_quality-checks.yaml
@@ -22,7 +22,6 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           charm-path: "${{ inputs.charm-path }}"
-          charmcraft-channel: latest/candidate # TODO: remove after charmcraft 3.3 stable release
 
   lint:
     name: Lint


### PR DESCRIPTION
Closes #96 
Reverts the changes done in #95 now that charmcraft 3.3 is [released to stable](https://snapcraft.io/charmcraft)