### PR TITLE
chore: add renovate config for pip version in charmcraft.yaml

### DIFF
--- a/default.json
+++ b/default.json
@@ -47,6 +47,19 @@
             "automerge": true
         }
     ],
+    "customManagers": [
+        {
+            "customType": "regex",
+            "fileMatch": [
+                "^charmcraft\\.yaml$"
+            ],
+            "matchStrings": [
+                "==(?<currentValue>[^ ]+) +# renovate: charmcraft-pip-latest"
+            ],
+            "depNameTemplate": "pip",
+            "datasourceTemplate": "pypi"
+        }
+    ],
     "schedule": [
         "on the 2nd and 4th day instance on sunday"
     ]


### PR DESCRIPTION
Adds a `customManager` to renovate config `default.json` to update the `pip` version in `charmcraft.yaml` files, similary to how it's done in [data-platform repos](https://github.com/canonical/data-platform/blob/main/renovate_presets/charm.json5#L120-L127).
This is now needed due to the changes in `charmcarft.yaml` in our multi-charm repos, these changes pin the pip version for reproducible builds, for example in https://github.com/canonical/kubeflow-tensorboards-operator/pull/158.

Tested on https://github.com/canonical/test-kubeflow-automation by:
1. pinning the renovate config to this branch in [renovate.json](https://github.com/canonical/test-kubeflow-automation/blob/renovate-charmcraft.yaml-build-tools/renovate.json#L4)
2. commiting a charmcraft.yaml with outdated pip version, snippet:
```
      PIP_BREAK_SYSTEM_PACKAGES=true python3 -m pip install --user --upgrade pip==24.3  # renovate: charmcraft-pip-latest
```
note: the latest in `24.x` is `24.3.1`
3. triggered renovate from the [Dependency dashboard](https://github.com/canonical/test-kubeflow-automation/issues/2)
4. expected PRs opened by renovate:
https://github.com/canonical/test-kubeflow-automation/pull/4
https://github.com/canonical/test-kubeflow-automation/pull/3