### PR TITLE
chore: add renovate config for rust version in charmcraft.yaml

### DIFF
--- a/default.json
+++ b/default.json
@@ -58,6 +58,18 @@
             ],
             "depNameTemplate": "pip",
             "datasourceTemplate": "pypi"
+        },
+        {
+            "customType": "regex",
+            "fileMatch": [
+                "^charmcraft\\.yaml$"
+            ],
+            "matchStrings": [
+                " (?<currentValue>[^ ]+) +# renovate: charmcraft-rust-latest"
+            ],
+            "packageNameTemplate": "rust-lang/rust",
+            "datasourceTemplate": "github-releases",
+            "versioningTemplate": "semver"
         }
     ],
     "schedule": [


### PR DESCRIPTION
Adds a `customManager` to renovate config `default.json` to update the rust version in `charmcraft.yaml` files, similary to how it's done in [data-platform repos](https://github.com/canonical/data-platform/blob/main/renovate_presets/charm.json5#L166-L174).
This is now needed due to the changes in `charmcarft.yaml` in our multi-charm repos, these changes pin the rust version for reproducible builds, for example in https://github.com/canonical/knative-operators/pull/282.

## Testing
Tested on https://github.com/canonical/test-kubeflow-automation by:
1. pinning the renovate config to this branch in [renovate.json](https://github.com/canonical/test-kubeflow-automation/blob/renovate-charmcraft.yaml-build-tools/renovate.json#L4)
2. commiting a charmcraft.yaml with outdated rust version, snippet:
```
      rustup default 1.82.0  # renovate: charmcraft-rust-latest
```
note: the latest is `1.84.1`
3. triggered renovate from the [Dependency dashboard](https://github.com/canonical/test-kubeflow-automation/issues/2)
4. expected PR opened by renovate: 
https://github.com/canonical/test-kubeflow-automation/pull/6

Closes #99 