### PR TITLE
fix: Make `rockcraft-channel` not required in build-rock action

### DIFF
--- a/.github/workflows/build-rock.yaml
+++ b/.github/workflows/build-rock.yaml
@@ -9,7 +9,7 @@ on:
         type: string
       rockcraft-channel:
         description: "Rockcraft channel e.g. latest/stable"
-        required: true
+        required: false
         default: "latest/stable"
         type: string
       source-branch:


### PR DESCRIPTION
Closes https://github.com/canonical/kubeflow-rocks/issues/205#issue-2955805898

This issue makes the `rockcraft-channel` input not required in the `build-rock` action. This makes sense because a default value is already provided (in this case "latest/stable")