### PR TITLE
feat: add rocks integration ci steps

### DIFF
--- a/.github/workflows/build-rock.yaml
+++ b/.github/workflows/build-rock.yaml
@@ -13,35 +13,27 @@ on:
         default: "latest/stable"
         type: string
       source-branch:
-        description: Github branch to checkout. If blank, it will use default values.
-        default: '' # For default behaviour, see https://github.com/actions/checkout/tree/v4/#usage
+        description: "Github branch to checkout. If blank, it will use default values."
+        default: ''
         required: false
         type: string
+
     outputs:
-        rock-artifact:
-          description: "Name of the artifact that the built ROCK has been uploaded to."
-          value: ${{ jobs.build-rock.outputs.rock-artifact}}
-        rock-reference:
-          description: "Rock reference to be used in order to copy the image to docker cache.
-            It consists of <rock-name>:<rock-version>."
-          value: ${{ jobs.build-rock.outputs.rock-reference}}
-        rock-filename:
-          description: "Filename of the .rock file produced"
-          value: ${{ jobs.build-rock.outputs.rock-filename}}
+      rock-artifact:
+        description: "Name of the artifact that the built ROCK has been uploaded to."
+        value: ${{ jobs.build-rock.outputs.rock-artifact }}
+      rock-filename:
+        description: "Filename of the .rock file produced"
+        value: ${{ jobs.build-rock.outputs.rock-filename }}
 
 jobs:
   build-rock:
     name: Build ${{ inputs.rock-dir }}
     runs-on: ubuntu-22.04
     outputs:
-      rock-reference: ${{ steps.metadata.outputs.rock-reference }}
-      rock-artifact: ${{ steps.metadata.outputs.rock-artifact}}
-      rock-filename: ${{ steps.metadata.outputs.rock-filename}}
+      rock-artifact: ${{ steps.metadata.outputs.rock-artifact }}
+      rock-filename: ${{ steps.metadata.outputs.rock-filename }}
     steps:
-      # Ideally we'd use self-hosted runners, but this effort is still not stable.
-      # This action will remove unused software (dotnet, haskell, android libs, codeql,
-      # and docker images) from the GH runner, which will liberate around 60 GB of storage
-      # distributed in 40GB for root and around 20 for a mnt point.
       - name: Maximise GH runner space
         uses: easimon/maximize-build-space@v7
         with:
@@ -66,11 +58,8 @@ jobs:
         id: metadata
         run: |
           NAME=$(yq eval ".name" rockcraft.yaml)
-          VERSION=$(yq eval ".version" rockcraft.yaml)
           ROCK=$(echo ${{ steps.rockcraft.outputs.rock }} | sed 's:.*/::')
-          ROCK_REFERENCE=$NAME:$VERSION
           echo "rock-artifact=$NAME" >> "$GITHUB_OUTPUT"
-          echo "rock-reference=$ROCK_REFERENCE" >> "$GITHUB_OUTPUT"
           echo "rock-filename=$ROCK" >> "$GITHUB_OUTPUT"
         working-directory: ${{ inputs.rock-dir }}
 

--- a/.github/workflows/build-rock.yaml
+++ b/.github/workflows/build-rock.yaml
@@ -13,14 +13,14 @@ on:
         default: "latest/stable"
         type: string
       source-branch:
-        description: "Github branch to checkout. If blank, it will use default values."
+        description: "GitHub branch to checkout. If blank, it will use default values."
         default: ''
         required: false
         type: string
 
     outputs:
       rock-artifact:
-        description: "Name of the artifact that the built ROCK has been uploaded to."
+        description: "Name of the artifact that the built rock has been uploaded to."
         value: ${{ jobs.build-rock.outputs.rock-artifact }}
       rock-filename:
         description: "Filename of the .rock file produced"
@@ -29,7 +29,7 @@ on:
 jobs:
   build-rock:
     name: Build ${{ inputs.rock-dir }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       rock-artifact: ${{ steps.metadata.outputs.rock-artifact }}
       rock-filename: ${{ steps.metadata.outputs.rock-filename }}

--- a/.github/workflows/build-scan-test-publish-rock.yaml
+++ b/.github/workflows/build-scan-test-publish-rock.yaml
@@ -34,7 +34,6 @@ jobs:
     uses: ./.github/workflows/resolve-image-tag.yaml
     with:
       rock-dir: ${{ inputs.rock-dir }}
-      registry: "docker.io/charmedkubeflow"
 
   build:
     uses: ./.github/workflows/build-rock.yaml

--- a/.github/workflows/build-scan-test-publish-rock.yaml
+++ b/.github/workflows/build-scan-test-publish-rock.yaml
@@ -80,7 +80,6 @@ jobs:
     with:
       rock-artifact: ${{ needs.build.outputs.rock-artifact }}
       rock-filename: ${{ needs.build.outputs.rock-filename }}
-      rock-reference: ${{ needs.resolve-image-tag.outputs.rock-reference }}
       full-image-tag: ${{ needs.resolve-image-tag.outputs.full-image-tag }}
 
   integrate-on-pr:

--- a/.github/workflows/build-scan-test-publish-rock.yaml
+++ b/.github/workflows/build-scan-test-publish-rock.yaml
@@ -75,3 +75,21 @@ jobs:
       rock-reference: ${{ needs.build.outputs.rock-reference }}
       rock-filename: ${{ needs.build.outputs.rock-filename }}
       registry: "charmedkubeflow"
+
+  integrate-on-pr:
+    if: ${{ github.event_name == 'pull_request' }}
+    uses: ./.github/workflows/integrate-rock.yaml
+    with:
+      rock-dir: ${{ inputs.rock-dir }}
+      event-name: ${{ github.event_name }}
+    secrets: inherit
+
+  integrate-on-merge:
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: publish
+    uses: ./.github/workflows/integrate-rock.yaml
+    with:
+      rock-dir: ${{ inputs.rock-dir }}
+      event-name: ${{ github.event_name }}
+      image-tag: ${{ needs.publish.outputs.published-image }}
+    secrets: inherit

--- a/.github/workflows/build-scan-test-publish-rock.yaml
+++ b/.github/workflows/build-scan-test-publish-rock.yaml
@@ -65,34 +65,40 @@ jobs:
       microk8s-channel: ${{ inputs.microk8s-channel }}
       juju-channel: ${{ inputs.juju-channel }}
       python-version: ${{ inputs.python-version }}
+  
+  resolve-image-tag:
+    needs: build
+    uses: ./.github/workflows/resolve-image-tag.yaml
+    with:
+      rock-reference: ${{ needs.build.outputs.rock-reference }}
+      registry: "docker.io/charmedkubeflow"
 
   publish:
     if: ${{ github.event_name == 'push' }}
-    needs: [scan, build, sanity-tests, integration-tests]
+    needs: [scan, build, sanity-tests, integration-tests, resolve-image-tag]
     uses: ./.github/workflows/publish-rock.yaml
     secrets: inherit
     with:
       rock-artifact: ${{ needs.build.outputs.rock-artifact }}
-      rock-reference: ${{ needs.build.outputs.rock-reference }}
       rock-filename: ${{ needs.build.outputs.rock-filename }}
-      registry: "docker.io/charmedkubeflow"
+      full-image-tag: ${{ needs.resolve-image-tag.outputs.full-image-tag }}
 
   integrate-on-pr:
     if: ${{ github.event_name == 'pull_request' }}
+    needs: [build, resolve-image-tag]
     uses: ./.github/workflows/integrate-rock.yaml
     with:
       rock-dir: ${{ inputs.rock-dir }}
       event-name: ${{ github.event_name }}
-      rock-reference: ${{ needs.build.outputs.rock-reference }}
-      registry: "docker.io/charmedkubeflow"
+      full-image-tag: ${{ needs.resolve-image-tag.outputs.full-image-tag }}
     secrets: inherit
 
   integrate-on-merge:
     if: ${{ github.event_name != 'pull_request' }}
-    needs: publish
+    needs: [publish, resolve-image-tag]
     uses: ./.github/workflows/integrate-rock.yaml
     with:
       rock-dir: ${{ inputs.rock-dir }}
       event-name: ${{ github.event_name }}
-      published-image: ${{ needs.publish.outputs.published-image }}
+      full-image-tag: ${{ needs.resolve-image-tag.outputs.full-image-tag }}
     secrets: inherit

--- a/.github/workflows/build-scan-test-publish-rock.yaml
+++ b/.github/workflows/build-scan-test-publish-rock.yaml
@@ -30,6 +30,12 @@ on:
 
 jobs:
 
+  resolve-image-tag:
+    uses: ./.github/workflows/resolve-image-tag.yaml
+    with:
+      rock-dir: ${{ inputs.rock-dir }}
+      registry: "docker.io/charmedkubeflow"
+
   build:
     uses: ./.github/workflows/build-rock.yaml
     with:
@@ -37,41 +43,34 @@ jobs:
       rockcraft-channel: ${{ inputs.rockcraft-channel }}
 
   scan:
-    needs: build
+    needs: [build, resolve-image-tag]
     uses: ./.github/workflows/scan-rock.yaml
     secrets: inherit
     with:
       rock-artifact: ${{ needs.build.outputs.rock-artifact }}
-      rock-reference: ${{ needs.build.outputs.rock-reference }}
+      rock-reference: ${{ needs.resolve-image-tag.outputs.rock-reference }}
       rock-filename: ${{ needs.build.outputs.rock-filename }}
 
   sanity-tests:
-    needs: build
+    needs: [build, resolve-image-tag]
     uses: ./.github/workflows/sanity-test-rock.yaml
     with:
       tests-dir: ${{ inputs.rock-dir }}
       rock-artifact: ${{ needs.build.outputs.rock-artifact }}
-      rock-reference: ${{ needs.build.outputs.rock-reference }}
+      rock-reference: ${{ needs.resolve-image-tag.outputs.rock-reference }}
       rock-filename: ${{ needs.build.outputs.rock-filename }}
 
   integration-tests:
-    needs: build
+    needs: [build, resolve-image-tag]
     uses: ./.github/workflows/integration-test-rock.yaml
     with:
       tests-dir: ${{ inputs.rock-dir }}
       rock-artifact: ${{ needs.build.outputs.rock-artifact }}
-      rock-reference: ${{ needs.build.outputs.rock-reference }}
+      rock-reference: ${{ needs.resolve-image-tag.outputs.rock-reference }}
       rock-filename: ${{ needs.build.outputs.rock-filename }}
       microk8s-channel: ${{ inputs.microk8s-channel }}
       juju-channel: ${{ inputs.juju-channel }}
       python-version: ${{ inputs.python-version }}
-  
-  resolve-image-tag:
-    needs: build
-    uses: ./.github/workflows/resolve-image-tag.yaml
-    with:
-      rock-reference: ${{ needs.build.outputs.rock-reference }}
-      registry: "docker.io/charmedkubeflow"
 
   publish:
     if: ${{ github.event_name == 'push' }}
@@ -81,11 +80,12 @@ jobs:
     with:
       rock-artifact: ${{ needs.build.outputs.rock-artifact }}
       rock-filename: ${{ needs.build.outputs.rock-filename }}
+      rock-reference: ${{ needs.resolve-image-tag.outputs.rock-reference }}
       full-image-tag: ${{ needs.resolve-image-tag.outputs.full-image-tag }}
 
   integrate-on-pr:
     if: ${{ github.event_name == 'pull_request' }}
-    needs: [build, resolve-image-tag]
+    needs: [resolve-image-tag]
     uses: ./.github/workflows/integrate-rock.yaml
     with:
       rock-dir: ${{ inputs.rock-dir }}

--- a/.github/workflows/build-scan-test-publish-rock.yaml
+++ b/.github/workflows/build-scan-test-publish-rock.yaml
@@ -27,6 +27,7 @@ on:
         default: ""
         required: false
         type: string
+
 jobs:
 
   build:
@@ -40,7 +41,7 @@ jobs:
     uses: ./.github/workflows/scan-rock.yaml
     secrets: inherit
     with:
-      rock-artifact: ${{ needs.build.outputs.rock-artifact}}
+      rock-artifact: ${{ needs.build.outputs.rock-artifact }}
       rock-reference: ${{ needs.build.outputs.rock-reference }}
       rock-filename: ${{ needs.build.outputs.rock-filename }}
 
@@ -49,7 +50,7 @@ jobs:
     uses: ./.github/workflows/sanity-test-rock.yaml
     with:
       tests-dir: ${{ inputs.rock-dir }}
-      rock-artifact: ${{ needs.build.outputs.rock-artifact}}
+      rock-artifact: ${{ needs.build.outputs.rock-artifact }}
       rock-reference: ${{ needs.build.outputs.rock-reference }}
       rock-filename: ${{ needs.build.outputs.rock-filename }}
 
@@ -58,7 +59,7 @@ jobs:
     uses: ./.github/workflows/integration-test-rock.yaml
     with:
       tests-dir: ${{ inputs.rock-dir }}
-      rock-artifact: ${{ needs.build.outputs.rock-artifact}}
+      rock-artifact: ${{ needs.build.outputs.rock-artifact }}
       rock-reference: ${{ needs.build.outputs.rock-reference }}
       rock-filename: ${{ needs.build.outputs.rock-filename }}
       microk8s-channel: ${{ inputs.microk8s-channel }}
@@ -71,10 +72,10 @@ jobs:
     uses: ./.github/workflows/publish-rock.yaml
     secrets: inherit
     with:
-      rock-artifact: ${{ needs.build.outputs.rock-artifact}}
+      rock-artifact: ${{ needs.build.outputs.rock-artifact }}
       rock-reference: ${{ needs.build.outputs.rock-reference }}
       rock-filename: ${{ needs.build.outputs.rock-filename }}
-      registry: "charmedkubeflow"
+      registry: "docker.io/charmedkubeflow"
 
   integrate-on-pr:
     if: ${{ github.event_name == 'pull_request' }}
@@ -82,6 +83,8 @@ jobs:
     with:
       rock-dir: ${{ inputs.rock-dir }}
       event-name: ${{ github.event_name }}
+      rock-reference: ${{ needs.build.outputs.rock-reference }}
+      registry: "docker.io/charmedkubeflow"
     secrets: inherit
 
   integrate-on-merge:
@@ -91,5 +94,5 @@ jobs:
     with:
       rock-dir: ${{ inputs.rock-dir }}
       event-name: ${{ github.event_name }}
-      image-tag: ${{ needs.publish.outputs.published-image }}
+      published-image: ${{ needs.publish.outputs.published-image }}
     secrets: inherit

--- a/.github/workflows/build-scan-test-publish-rock.yaml
+++ b/.github/workflows/build-scan-test-publish-rock.yaml
@@ -59,22 +59,21 @@ jobs:
       rock-reference: ${{ needs.resolve-image-tag.outputs.rock-reference }}
       rock-filename: ${{ needs.build.outputs.rock-filename }}
 
-  # integration-tests:
-  #   needs: [build, resolve-image-tag]
-  #   uses: ./.github/workflows/integration-test-rock.yaml
-  #   with:
-  #     tests-dir: ${{ inputs.rock-dir }}
-  #     rock-artifact: ${{ needs.build.outputs.rock-artifact }}
-  #     rock-reference: ${{ needs.resolve-image-tag.outputs.rock-reference }}
-  #     rock-filename: ${{ needs.build.outputs.rock-filename }}
-  #     microk8s-channel: ${{ inputs.microk8s-channel }}
-  #     juju-channel: ${{ inputs.juju-channel }}
-  #     python-version: ${{ inputs.python-version }}
+  integration-tests:
+    needs: [build, resolve-image-tag]
+    uses: ./.github/workflows/integration-test-rock.yaml
+    with:
+      tests-dir: ${{ inputs.rock-dir }}
+      rock-artifact: ${{ needs.build.outputs.rock-artifact }}
+      rock-reference: ${{ needs.resolve-image-tag.outputs.rock-reference }}
+      rock-filename: ${{ needs.build.outputs.rock-filename }}
+      microk8s-channel: ${{ inputs.microk8s-channel }}
+      juju-channel: ${{ inputs.juju-channel }}
+      python-version: ${{ inputs.python-version }}
 
   publish:
     if: ${{ github.event_name == 'push' }}
-    # needs: [scan, build, sanity-tests, integration-tests, resolve-image-tag]
-    needs: [scan, build, sanity-tests, resolve-image-tag]
+    needs: [scan, build, sanity-tests, integration-tests, resolve-image-tag]
     uses: ./.github/workflows/publish-rock.yaml
     secrets: inherit
     with:

--- a/.github/workflows/build-scan-test-publish-rock.yaml
+++ b/.github/workflows/build-scan-test-publish-rock.yaml
@@ -59,21 +59,22 @@ jobs:
       rock-reference: ${{ needs.resolve-image-tag.outputs.rock-reference }}
       rock-filename: ${{ needs.build.outputs.rock-filename }}
 
-  integration-tests:
-    needs: [build, resolve-image-tag]
-    uses: ./.github/workflows/integration-test-rock.yaml
-    with:
-      tests-dir: ${{ inputs.rock-dir }}
-      rock-artifact: ${{ needs.build.outputs.rock-artifact }}
-      rock-reference: ${{ needs.resolve-image-tag.outputs.rock-reference }}
-      rock-filename: ${{ needs.build.outputs.rock-filename }}
-      microk8s-channel: ${{ inputs.microk8s-channel }}
-      juju-channel: ${{ inputs.juju-channel }}
-      python-version: ${{ inputs.python-version }}
+  # integration-tests:
+  #   needs: [build, resolve-image-tag]
+  #   uses: ./.github/workflows/integration-test-rock.yaml
+  #   with:
+  #     tests-dir: ${{ inputs.rock-dir }}
+  #     rock-artifact: ${{ needs.build.outputs.rock-artifact }}
+  #     rock-reference: ${{ needs.resolve-image-tag.outputs.rock-reference }}
+  #     rock-filename: ${{ needs.build.outputs.rock-filename }}
+  #     microk8s-channel: ${{ inputs.microk8s-channel }}
+  #     juju-channel: ${{ inputs.juju-channel }}
+  #     python-version: ${{ inputs.python-version }}
 
   publish:
     if: ${{ github.event_name == 'push' }}
-    needs: [scan, build, sanity-tests, integration-tests, resolve-image-tag]
+    # needs: [scan, build, sanity-tests, integration-tests, resolve-image-tag]
+    needs: [scan, build, sanity-tests, resolve-image-tag]
     uses: ./.github/workflows/publish-rock.yaml
     secrets: inherit
     with:

--- a/.github/workflows/integrate-rock.yaml
+++ b/.github/workflows/integrate-rock.yaml
@@ -9,18 +9,9 @@ on:
       event-name:
         required: true
         type: string
-      published-image:
-        description: "Full image reference published to registry (used for merged PRs)"
-        required: false
-        type: string
-      rock-reference:
-        description: "Rock reference in <name>:<version> form (used in PRs)"
-        required: false
-        type: string
-      registry:
-        description: "Docker registry base (used in PRs)"
-        required: false
-        default: "docker.io/charmedkubeflow"
+      full-image-tag:
+        description: "Full image reference to the built and pushed rock image"
+        required: true
         type: string
 
   workflow_dispatch:
@@ -38,23 +29,14 @@ on:
         required: false
         default: true
         type: boolean
-      published-image:
+      full-image-tag:
         description: "Full image reference from Docker registry"
-        required: false
+        required: true
         type: string
-      rock-reference:
-        description: "Rock reference (e.g. api-server:2.5.0)"
-        required: false
-        type: string
-      registry:
-        description: "Docker registry base (e.g. docker.io/charmedkubeflow)"
-        required: false
-        type: string
-        default: "docker.io/charmedkubeflow"
 
 jobs:
   integrate-rock:
-    name: Integrate ${{ inputs.rock-reference }}
+    name: Integrate ROCK from ${{ inputs.full-image-tag }}
     runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -68,23 +50,6 @@ jobs:
 
       - name: Install yq
         run: sudo snap install yq
-
-      - name: Determine image tag
-        id: tag
-        run: |
-          if [[ -n "${{ inputs.published-image }}" ]]; then
-            echo "Using published image: ${{ inputs.published-image }}"
-            echo "final_tag=${{ inputs.published-image }}" >> $GITHUB_OUTPUT
-          elif [[ -n "${{ inputs.rock-reference }}" ]]; then
-            echo "Constructing image tag from rock-reference and registry"
-            COMMIT_ID=$(git rev-parse --short HEAD)
-            FINAL_TAG="${{ inputs.registry }}/${{ inputs.rock-reference }}-${COMMIT_ID}"
-            echo "Generated image tag: $FINAL_TAG"
-            echo "final_tag=$FINAL_TAG" >> $GITHUB_OUTPUT
-          else
-            echo "❌ Error: Neither 'published-image' nor 'rock-reference' provided"
-            exit 1
-          fi
 
       - name: Determine target branch and dry-run
         id: params
@@ -132,6 +97,6 @@ jobs:
           chaci integrate-rock \
             "${{ inputs.rock-dir }}/rock-ci-metadata.yaml" \
             "${{ steps.params.outputs.target_branch }}" \
-            "${{ steps.tag.outputs.final_tag }}" \
+            "${{ inputs.full-image-tag }}" \
             ${{ steps.params.outputs.dry_run }} \
             $([[ -n "${{ steps.triggering_pr.outputs.url }}" ]] && echo "--triggering-pr ${{ steps.triggering_pr.outputs.url }}")

--- a/.github/workflows/integrate-rock.yaml
+++ b/.github/workflows/integrate-rock.yaml
@@ -54,6 +54,7 @@ on:
 
 jobs:
   integrate-rock:
+    name: Integrate ${{ inputs.rock-reference }}
     runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integrate-rock.yaml
+++ b/.github/workflows/integrate-rock.yaml
@@ -1,4 +1,4 @@
-name: Integrate ROCK into charm
+name: Integrate rock into charm
 
 on:
   workflow_call:
@@ -25,7 +25,7 @@ on:
         required: true
         type: string
       dry-run:
-        description: "Run in dry-run mode?"
+        description: "Whether to run `chaci integrate-rock` in dry-run mode or not"
         required: false
         default: true
         type: boolean
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install charmed-analytics-ci
-        run: pip install charmed-analytics-ci==1.1.0
+        run: pipx install charmed-analytics-ci==1.1.0
 
       - name: Install yq
         run: sudo snap install yq
@@ -75,7 +75,13 @@ jobs:
       - name: Determine triggering PR (if merged)
         id: triggering_pr
         run: |
-          if [[ "${{ inputs.event-name }}" != "pull_request" ]]; then
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "Workflow dispatch — skipping triggering PR detection."
+            echo "url=" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ inputs.event-name }}" == "pull_request" ]]; then
+            echo "PR event — skipping triggering PR detection."
+            echo "url=" >> "$GITHUB_OUTPUT"
+          else
             sudo apt update && sudo apt install -y gh
 
             pr_number=$(gh pr list --state merged --search "$(git rev-parse --short HEAD)" --json number --jq '.[0].number' || true)
@@ -88,12 +94,9 @@ jobs:
               echo "No triggering PR found."
               echo "url=" >> "$GITHUB_OUTPUT"
             fi
-          else
-            echo "PR event — skipping triggering PR detection."
-            echo "url=" >> "$GITHUB_OUTPUT"
           fi
-      
-      - name: Import and configure the GPG key for CHACI
+
+      - name: Import and configure the GPG key for chaci
         uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec
         with:
           gpg_private_key: ${{ secrets.CHACI_GPG_PRIVATE }}

--- a/.github/workflows/integrate-rock.yaml
+++ b/.github/workflows/integrate-rock.yaml
@@ -36,7 +36,7 @@ on:
 
 jobs:
   integrate-rock:
-    name: Integrate ROCK from ${{ inputs.full-image-tag }}
+    name: Integrate ${{ inputs.full-image-tag }}
     runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integrate-rock.yaml
+++ b/.github/workflows/integrate-rock.yaml
@@ -39,7 +39,7 @@ jobs:
     name: Integrate ${{ inputs.full-image-tag }}
     runs-on: ubuntu-24.04
     env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/integrate-rock.yaml
+++ b/.github/workflows/integrate-rock.yaml
@@ -9,14 +9,19 @@ on:
       event-name:
         required: true
         type: string
-      image-tag:
-        description: "Full image tag (e.g. my-rock/1.2.3-commitid)"
+      published-image:
+        description: "Full image reference published to registry (used for merged PRs)"
         required: false
         type: string
-      image-prefix:
+      rock-reference:
+        description: "Rock reference in <name>:<version> form (used in PRs)"
         required: false
         type: string
-        default: "docker.io/charmedkubeflow/"
+      registry:
+        description: "Docker registry base (used in PRs)"
+        required: false
+        default: "docker.io/charmedkubeflow"
+        type: string
 
   workflow_dispatch:
     inputs:
@@ -33,15 +38,19 @@ on:
         required: false
         default: true
         type: boolean
-      image-tag:
-        description: "Full rock image tag (e.g. my-rock/1.2.3-commitid)"
-        required: true
-        type: string
-      image-prefix:
-        description: Rock image prefix used only if no image-tag provided
+      published-image:
+        description: "Full image reference from Docker registry"
         required: false
         type: string
-        default: "docker.io/charmedkubeflow/"
+      rock-reference:
+        description: "Rock reference (e.g. api-server:2.5.0)"
+        required: false
+        type: string
+      registry:
+        description: "Docker registry base (e.g. docker.io/charmedkubeflow)"
+        required: false
+        type: string
+        default: "docker.io/charmedkubeflow"
 
 jobs:
   integrate-rock:
@@ -62,19 +71,18 @@ jobs:
       - name: Determine image tag
         id: tag
         run: |
-          if [[ -n "${{ inputs.image-tag }}" ]]; then
-            echo "Using provided image tag: ${{ inputs.image-tag }}"
-            echo "final_tag=${{ inputs.image-tag }}" >> $GITHUB_OUTPUT
-          else
-            echo "No image-tag provided — constructing from rockcraft.yaml"
-            ROCKCRAFT_YAML="${{ inputs.rock-dir }}/rockcraft.yaml"
-            IMAGE_NAME=$(yq '.name' "$ROCKCRAFT_YAML")
-            IMAGE_VERSION=$(yq '.version' "$ROCKCRAFT_YAML")
+          if [[ -n "${{ inputs.published-image }}" ]]; then
+            echo "Using published image: ${{ inputs.published-image }}"
+            echo "final_tag=${{ inputs.published-image }}" >> $GITHUB_OUTPUT
+          elif [[ -n "${{ inputs.rock-reference }}" ]]; then
+            echo "Constructing image tag from rock-reference and registry"
             COMMIT_ID=$(git rev-parse --short HEAD)
-            PREFIX="${{ inputs.image-prefix }}"
-            FINAL_TAG="${PREFIX}${IMAGE_NAME}:${IMAGE_VERSION}-${COMMIT_ID}"
+            FINAL_TAG="${{ inputs.registry }}/${{ inputs.rock-reference }}-${COMMIT_ID}"
             echo "Generated image tag: $FINAL_TAG"
             echo "final_tag=$FINAL_TAG" >> $GITHUB_OUTPUT
+          else
+            echo "❌ Error: Neither 'published-image' nor 'rock-reference' provided"
+            exit 1
           fi
 
       - name: Determine target branch and dry-run
@@ -96,7 +104,7 @@ jobs:
               echo "dry_run=" >> $GITHUB_OUTPUT
             fi
           fi
-      
+
       - name: Determine triggering PR (if merged)
         id: triggering_pr
         run: |
@@ -126,4 +134,3 @@ jobs:
             "${{ steps.tag.outputs.final_tag }}" \
             ${{ steps.params.outputs.dry_run }} \
             $([[ -n "${{ steps.triggering_pr.outputs.url }}" ]] && echo "--triggering-pr ${{ steps.triggering_pr.outputs.url }}")
-

--- a/.github/workflows/integrate-rock.yaml
+++ b/.github/workflows/integrate-rock.yaml
@@ -13,6 +13,10 @@ on:
         description: "Full image tag (e.g. my-rock/1.2.3-commitid)"
         required: false
         type: string
+      image-prefix:
+        required: false
+        type: string
+        default: "docker.io/charmedkubeflow/"
 
   workflow_dispatch:
     inputs:
@@ -33,6 +37,11 @@ on:
         description: "Full rock image tag (e.g. my-rock/1.2.3-commitid)"
         required: true
         type: string
+      image-prefix:
+        description: Rock image prefix used only if no image-tag provided
+        required: false
+        type: string
+        default: "docker.io/charmedkubeflow/"
 
 jobs:
   integrate-rock:
@@ -57,12 +66,15 @@ jobs:
             echo "Using provided image tag: ${{ inputs.image-tag }}"
             echo "final_tag=${{ inputs.image-tag }}" >> $GITHUB_OUTPUT
           else
+            echo "No image-tag provided — constructing from rockcraft.yaml"
             ROCKCRAFT_YAML="${{ inputs.rock-dir }}/rockcraft.yaml"
             IMAGE_NAME=$(yq '.name' "$ROCKCRAFT_YAML")
             IMAGE_VERSION=$(yq '.version' "$ROCKCRAFT_YAML")
             COMMIT_ID=$(git rev-parse --short HEAD)
-            echo "Generated image tag: $IMAGE_NAME/$IMAGE_VERSION-$COMMIT_ID"
-            echo "final_tag=$IMAGE_NAME/$IMAGE_VERSION-$COMMIT_ID" >> $GITHUB_OUTPUT
+            PREFIX="${{ inputs.image-prefix }}"
+            FINAL_TAG="${PREFIX}${IMAGE_NAME}:${IMAGE_VERSION}-${COMMIT_ID}"
+            echo "Generated image tag: $FINAL_TAG"
+            echo "final_tag=$FINAL_TAG" >> $GITHUB_OUTPUT
           fi
 
       - name: Determine target branch and dry-run

--- a/.github/workflows/integrate-rock.yaml
+++ b/.github/workflows/integrate-rock.yaml
@@ -1,0 +1,117 @@
+name: Integrate ROCK into charm
+
+on:
+  workflow_call:
+    inputs:
+      rock-dir:
+        required: true
+        type: string
+      event-name:
+        required: true
+        type: string
+      image-tag:
+        description: "Full image tag (e.g. my-rock/1.2.3-commitid)"
+        required: false
+        type: string
+
+  workflow_dispatch:
+    inputs:
+      rock-dir:
+        description: "Path to the rock directory (e.g. rocks/my-rock)"
+        required: true
+        type: string
+      target-branch:
+        description: "Branch to integrate into"
+        required: true
+        type: string
+      dry-run:
+        description: "Run in dry-run mode?"
+        required: false
+        default: true
+        type: boolean
+      image-tag:
+        description: "Full rock image tag (e.g. my-rock/1.2.3-commitid)"
+        required: true
+        type: string
+
+jobs:
+  integrate-rock:
+    runs-on: ubuntu-24.04
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Install charmed-analytics-ci
+        run: pip install charmed-analytics-ci
+
+      - name: Install yq
+        run: sudo snap install yq
+
+      - name: Determine image tag
+        id: tag
+        run: |
+          if [[ -n "${{ inputs.image-tag }}" ]]; then
+            echo "Using provided image tag: ${{ inputs.image-tag }}"
+            echo "final_tag=${{ inputs.image-tag }}" >> $GITHUB_OUTPUT
+          else
+            ROCKCRAFT_YAML="${{ inputs.rock-dir }}/rockcraft.yaml"
+            IMAGE_NAME=$(yq '.name' "$ROCKCRAFT_YAML")
+            IMAGE_VERSION=$(yq '.version' "$ROCKCRAFT_YAML")
+            COMMIT_ID=$(git rev-parse --short HEAD)
+            echo "Generated image tag: $IMAGE_NAME/$IMAGE_VERSION-$COMMIT_ID"
+            echo "final_tag=$IMAGE_NAME/$IMAGE_VERSION-$COMMIT_ID" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Determine target branch and dry-run
+        id: params
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "target_branch=${{ inputs.target-branch }}" >> $GITHUB_OUTPUT
+            if [[ "${{ inputs.dry-run }}" == "true" ]]; then
+              echo "dry_run=--dry-run" >> $GITHUB_OUTPUT
+            else
+              echo "dry_run=" >> $GITHUB_OUTPUT
+            fi
+          else
+            if [[ "${{ inputs.event-name }}" == "pull_request" ]]; then
+              echo "target_branch=main" >> $GITHUB_OUTPUT
+              echo "dry_run=--dry-run" >> $GITHUB_OUTPUT
+            else
+              echo "target_branch=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
+              echo "dry_run=" >> $GITHUB_OUTPUT
+            fi
+          fi
+      
+      - name: Determine triggering PR (if merged)
+        id: triggering_pr
+        run: |
+          if [[ "${{ inputs.event-name }}" != "pull_request" ]]; then
+            sudo apt update && sudo apt install -y gh
+
+            pr_number=$(gh pr list --state merged --search "$(git rev-parse --short HEAD)" --json number --jq '.[0].number' || true)
+
+            if [[ -n "$pr_number" ]]; then
+              pr_url="https://github.com/${{ github.repository }}/pull/$pr_number"
+              echo "Found triggering PR: $pr_url"
+              echo "url=$pr_url" >> "$GITHUB_OUTPUT"
+            else
+              echo "No triggering PR found."
+              echo "url=" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "PR event — skipping triggering PR detection."
+            echo "url=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run chaci integrate-rock
+        run: |
+          chaci integrate-rock \
+            "${{ inputs.rock-dir }}/rock-ci-metadata.yaml" \
+            "${{ steps.params.outputs.target_branch }}" \
+            "${{ steps.tag.outputs.final_tag }}" \
+            ${{ steps.params.outputs.dry_run }} \
+            $([[ -n "${{ steps.triggering_pr.outputs.url }}" ]] && echo "--triggering-pr ${{ steps.triggering_pr.outputs.url }}")
+

--- a/.github/workflows/integrate-rock.yaml
+++ b/.github/workflows/integrate-rock.yaml
@@ -40,13 +40,14 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      GH_USER_EMAIL: ${{ secrets.GH_USER_EMAIL }}
 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
 
       - name: Install charmed-analytics-ci
-        run: pip install charmed-analytics-ci
+        run: pip install charmed-analytics-ci==1.1.0
 
       - name: Install yq
         run: sudo snap install yq
@@ -91,6 +92,16 @@ jobs:
             echo "PR event — skipping triggering PR detection."
             echo "url=" >> "$GITHUB_OUTPUT"
           fi
+      
+      - name: Import and configure the GPG key for CHACI
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec
+        with:
+          gpg_private_key: ${{ secrets.CHACI_GPG_PRIVATE }}
+          passphrase: ${{ secrets.CHACI_GPG_PASSPHRASE }}
+          git_config_global: true
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_user_email: ${{ secrets.GH_USER_EMAIL }}
 
       - name: Run chaci integrate-rock
         run: |

--- a/.github/workflows/publish-rock.yaml
+++ b/.github/workflows/publish-rock.yaml
@@ -16,7 +16,7 @@ on:
         required: true
         type: string
       source-branch:
-        description: "GitHub branch to checkout. If blank, it will use default values."
+        description: "GitHub branch to checkout. If blank, it will use the default branch of the repository."
         default: ''
         required: false
         type: string
@@ -24,7 +24,7 @@ on:
 jobs:
   publish-rock:
     name: Publish ${{ inputs.full-image-tag }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       published-image: ${{ steps.push.outputs.image }}
     steps:
@@ -34,7 +34,7 @@ jobs:
           ref: ${{ inputs.source-branch }}
 
       - name: Install Rockcraft
-        run: sudo snap install rockcraft --classic --edge
+        run: sudo snap install rockcraft --classic
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/publish-rock.yaml
+++ b/.github/workflows/publish-rock.yaml
@@ -29,6 +29,8 @@ jobs:
   publish-rock:
     name: Publish ${{ inputs.rock-reference }}
     runs-on: ubuntu-22.04
+    outputs:
+      published-image: ${{ steps.rock_in_docker.outputs.image }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/publish-rock.yaml
+++ b/.github/workflows/publish-rock.yaml
@@ -7,36 +7,32 @@ on:
         description: "Name of the artifact from which the ROCK will be downloaded."
         required: true
         type: string
-      rock-reference:
-        description: "Rock reference to be used in order to copy the image to docker cache.
-          It consists of <rock-name>:<rock-version>."
-        required: true
-        type: string
       rock-filename:
         description: "Filename of the .rock file"
         required: true
         type: string
-      registry:
-        description: "Registry where the image will be published"
+      full-image-tag:
+        description: "Full image tag to publish (e.g. docker.io/org/rock:version-commit)"
         required: true
         type: string
       source-branch:
-        description: Github branch to checkout. If blank, it will use default values.
-        default: '' # For default behaviour, see https://github.com/actions/checkout/tree/v4/#usage
+        description: "GitHub branch to checkout. If blank, it will use default values."
+        default: ''
         required: false
         type: string
+
 jobs:
   publish-rock:
-    name: Publish ${{ inputs.rock-reference }}
+    name: Publish ${{ inputs.full-image-tag }}
     runs-on: ubuntu-22.04
     outputs:
-      published-image: ${{ steps.rock_in_docker.outputs.image }}
+      published-image: ${{ steps.push.outputs.image }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.source-branch }}
-      
+
       - name: Install Rockcraft
         run: sudo snap install rockcraft --classic --edge
 
@@ -51,22 +47,25 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Export ROCK to Docker
-        id: rock_in_docker
         run: |
-          COMMIT_ID=$(git rev-parse --short HEAD)
-          DOCKER_IMAGE=${{ inputs.rock-reference }}-$COMMIT_ID
-          sudo rockcraft.skopeo --insecure-policy copy oci-archive:${{ inputs.rock-filename }} docker-daemon:${{ inputs.registry }}/$DOCKER_IMAGE
-          echo "image=$DOCKER_IMAGE" >> "$GITHUB_OUTPUT"
+          echo "Exporting image to Docker: ${{ inputs.full-image-tag }}"
+          sudo rockcraft.skopeo --insecure-policy copy \
+            oci-archive:${{ inputs.rock-filename }} \
+            docker-daemon:${{ inputs.full-image-tag }}
 
-      - name: Publish to dockerhub
+      - name: Publish to Docker Hub
+        id: push
         run: |
-          # Check if image already exists on dockerhub and publish
-          # Returns 0 if exists, 1 if it doesn't
-          IMAGE_EXISTS=$(docker manifest inspect ${{ inputs.registry }}/${{ steps.rock_in_docker.outputs.image }} > /dev/null ; echo $?)
-          if [[ "$IMAGE_EXISTS" == "0" ]]
-          then
-            echo "Image ${{ steps.rock_in_docker.outputs.image }} already exists in dockerhub registry ${{ inputs.registry }}"
+          IMAGE="${{ inputs.full-image-tag }}"
+          echo "Checking if image exists: $IMAGE"
+          IMAGE_EXISTS=$(docker manifest inspect "$IMAGE" > /dev/null 2>&1 ; echo $?)
+
+          if [[ "$IMAGE_EXISTS" == "0" ]]; then
+            echo "Image $IMAGE already exists in Docker Hub — skipping push."
             exit 1
           else
-            docker push ${{ inputs.registry }}/${{ steps.rock_in_docker.outputs.image }}
+            echo "Pushing image to Docker Hub: $IMAGE"
+            docker push "$IMAGE"
           fi
+
+          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/resolve-image-tag.yaml
+++ b/.github/workflows/resolve-image-tag.yaml
@@ -19,7 +19,7 @@ on:
 jobs:
   resolve:
     name: Resolve tag ${{ inputs.rock-dir }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       rock-reference: ${{ steps.extract.outputs.rock-reference }}
       full-image-tag: ${{ steps.extract.outputs.full-image-tag }}

--- a/.github/workflows/resolve-image-tag.yaml
+++ b/.github/workflows/resolve-image-tag.yaml
@@ -7,11 +7,6 @@ on:
         description: "Path to rock directory with rockcraft.yaml"
         required: true
         type: string
-      registry:
-        description: "Image registry prefix"
-        required: false
-        default: "docker.io/charmedkubeflow"
-        type: string
 
     outputs:
       rock-reference:
@@ -23,10 +18,13 @@ on:
 
 jobs:
   resolve:
+    name: Resolve tag ${{ inputs.rock-dir }}
     runs-on: ubuntu-22.04
     outputs:
       rock-reference: ${{ steps.extract.outputs.rock-reference }}
       full-image-tag: ${{ steps.extract.outputs.full-image-tag }}
+    env:
+      REGISTRY: ${{ vars.ROCK_IMAGE_REGISTRY }}
 
     steps:
       - name: Checkout repo
@@ -44,7 +42,7 @@ jobs:
           COMMIT_ID=$(git rev-parse --short HEAD)
 
           ROCK_REFERENCE="${NAME}:${VERSION}"
-          FULL_IMAGE_TAG="${{ inputs.registry }}/${ROCK_REFERENCE}-${COMMIT_ID}"
+          FULL_IMAGE_TAG="${REGISTRY}/${ROCK_REFERENCE}-${COMMIT_ID}"
 
           echo "rock-reference=$ROCK_REFERENCE" >> "$GITHUB_OUTPUT"
           echo "full-image-tag=$FULL_IMAGE_TAG" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/resolve-image-tag.yaml
+++ b/.github/workflows/resolve-image-tag.yaml
@@ -1,37 +1,50 @@
-name: Resolve full image tag
+name: Resolve image tag
 
 on:
   workflow_call:
     inputs:
-      rock-reference:
-        description: "<rock-name>:<rock-version>"
+      rock-dir:
+        description: "Path to rock directory with rockcraft.yaml"
         required: true
         type: string
       registry:
-        description: "Image registry"
+        description: "Image registry prefix"
         required: false
         default: "docker.io/charmedkubeflow"
         type: string
 
     outputs:
+      rock-reference:
+        description: "<rock-name>:<version> format"
+        value: ${{ jobs.resolve.outputs.rock-reference }}
       full-image-tag:
-        description: "Full image tag with registry, rock name, version, and commit"
+        description: "Fully qualified image tag"
         value: ${{ jobs.resolve.outputs.full-image-tag }}
 
 jobs:
   resolve:
-    runs-on: ubuntu-24.04
-    name: Resolve tag ${{ inputs.rock-reference }}
+    runs-on: ubuntu-22.04
     outputs:
-      full-image-tag: ${{ steps.set.outputs.full-image-tag }}
+      rock-reference: ${{ steps.extract.outputs.rock-reference }}
+      full-image-tag: ${{ steps.extract.outputs.full-image-tag }}
+
     steps:
-      - name: Checkout
+      - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Calculate image tag
-        id: set
+      - name: Install yq
+        run: sudo snap install yq
+
+      - name: Extract and construct image tag
+        id: extract
+        working-directory: ${{ inputs.rock-dir }}
         run: |
+          NAME=$(yq '.name' rockcraft.yaml)
+          VERSION=$(yq '.version' rockcraft.yaml)
           COMMIT_ID=$(git rev-parse --short HEAD)
-          IMAGE_TAG="${{ inputs.registry }}/${{ inputs.rock-reference }}-${COMMIT_ID}"
-          echo "Resolved image tag: $IMAGE_TAG"
-          echo "full-image-tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+          ROCK_REFERENCE="${NAME}:${VERSION}"
+          FULL_IMAGE_TAG="${{ inputs.registry }}/${ROCK_REFERENCE}-${COMMIT_ID}"
+
+          echo "rock-reference=$ROCK_REFERENCE" >> "$GITHUB_OUTPUT"
+          echo "full-image-tag=$FULL_IMAGE_TAG" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/resolve-image-tag.yaml
+++ b/.github/workflows/resolve-image-tag.yaml
@@ -1,0 +1,37 @@
+name: Resolve full image tag
+
+on:
+  workflow_call:
+    inputs:
+      rock-reference:
+        description: "<rock-name>:<rock-version>"
+        required: true
+        type: string
+      registry:
+        description: "Image registry"
+        required: false
+        default: "docker.io/charmedkubeflow"
+        type: string
+
+    outputs:
+      full-image-tag:
+        description: "Full image tag with registry, rock name, version, and commit"
+        value: ${{ jobs.resolve.outputs.full-image-tag }}
+
+jobs:
+  resolve:
+    runs-on: ubuntu-24.04
+    name: Resolve tag ${{ inputs.rock-reference }}
+    outputs:
+      full-image-tag: ${{ steps.set.outputs.full-image-tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Calculate image tag
+        id: set
+        run: |
+          COMMIT_ID=$(git rev-parse --short HEAD)
+          IMAGE_TAG="${{ inputs.registry }}/${{ inputs.rock-reference }}-${COMMIT_ID}"
+          echo "Resolved image tag: $IMAGE_TAG"
+          echo "full-image-tag=$IMAGE_TAG" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Closes: https://github.com/canonical/charmed-kubeflow-workflows/issues/111

# Integrate ROCK Images into Charms Using CHACI (PR + Merge Support)

## Summary

This PR introduces a new GitHub Actions workflow (`integrate-rock.yaml`) to enable automatic ROCK image integration into charm repositories using the **[CHACI](https://github.com/canonical/charmed-analytics-ci)** tool. The integration is triggered both on pull requests and after merges, streamlining the update of charm metadata with the correct image tag.

---

## What’s Added

- **`integrate-rock.yaml`**:
  - A new reusable workflow that uses `chaci integrate-rock` to update charm metadata based on the built ROCK image.
  - Supports both `workflow_dispatch` (manual) and `workflow_call` (automated) triggers.
  - Detects PR vs merge context and adjusts target branch and dry-run behavior accordingly.
  - GPG signing is configured via `crazy-max/ghaction-import-gpg`.

---

## Where It’s Used

In `.github/workflows/build-scan-test-publish-rock.yaml`:
- **`integrate-on-pr`**: Runs during PRs in dry-run mode to validate CHACI integration logic.
- **`integrate-on-merge`**: Runs after PRs are merged to main, applying metadata updates to target charm repositories.

Both jobs use:
- `full-image-tag` resolved via the new `resolve-image-tag.yaml` workflow.
- ROCK image data generated from the build pipeline.

---

## Benefits

- **Automates charm integration** after ROCK builds.
- **Validates integration during PRs** without modifying external repos (dry-run).
- **Guarantees up-to-date metadata** in downstream charm repos.
- **Reduces manual effort and risk of inconsistencies**.

---

## How It Was Tested

To validate the functionality end-to-end:

1. **Forked the workflows repo** to [misohu/charmed-kubeflow-workflows](https://github.com/misohu/charmed-kubeflow-workflows).
2. **Forked the pipelines-rocks repo** to [misohu/pipelines-rocks](https://github.com/misohu/pipelines-rocks).
3. Created a test PR [#6](https://github.com/misohu/pipelines-rocks/pull/6) in the pipelines repo, including a `rock-ci-metadata.yaml` file to trigger integration.
4. On PR creation:
   - The CI ran the `integrate-on-pr` job in dry-run mode.
   - ✅ [Dry-run job passed](https://github.com/misohu/pipelines-rocks/actions/runs/16415939692/job/46381813059#step:7:33), confirming correct CHACI invocation.
5. Merged the test PR to `main`.
   - This triggered the `integrate-on-merge` job via `build-scan-test-publish-rock.yaml`.
   - ✅ [Post-merge CI succeeded](https://github.com/misohu/pipelines-rocks/actions/runs/16472454689/job/46565987867) and **automatically opened a PR in the charm repo**.
6. Verified that CHACI successfully opened a PR in the downstream charm repo:
   - 🎉 [canonical/kfp-operators#747](https://github.com/canonical/kfp-operators/pull/747)