### PR TITLE
chore: disable renovate

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,3 +1,79 @@
 {
     "enabled": false
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "rebaseWhen": "behind-base-branch",
+    "dependencyDashboard": false,
+    "branchPrefix": "renovate-",
+    "constraints": {
+        "python": "3.8.10"
+    },
+    "pip-compile": {
+        "fileMatch": [
+            "(^|/)requirements\\.in$",
+            "(^|/)requirements-fmt\\.in$",
+            "(^|/)requirements-lint\\.in$",
+            "(^|/)requirements-unit\\.in$",
+            "(^|/)requirements-integration\\.in$",
+            "(^|/)requirements.*\\.in$"
+        ],
+        "lockFileMaintenance": {
+            "enabled": true,
+            "schedule": [
+                "on the 2nd and 4th day instance on sunday"
+            ]
+        }
+    },
+    "pip_requirements": {
+        "enabled": false
+    },
+    "automergeType": "branch",
+    "packageRules": [
+        {
+            "groupName": "testing deps",
+            "matchPackagePatterns": [
+                "^black$",
+                "codespell",
+                "flake8",
+                "flake8-builtins",
+                "flake8-copyright",
+                "flake8-docstrings",
+                "isort",
+                "pep8-naming",
+                "pyproject-flake8",
+                "pytest",
+                "pytest-asyncio",
+                "selenium",
+                "selenium-wire"
+            ],
+            "automerge": true
+        }
+    ],
+    "customManagers": [
+        {
+            "customType": "regex",
+            "fileMatch": [
+                "^charmcraft\\.yaml$"
+            ],
+            "matchStrings": [
+                "==(?<currentValue>[^ ]+) +# renovate: charmcraft-pip-latest"
+            ],
+            "depNameTemplate": "pip",
+            "datasourceTemplate": "pypi"
+        },
+        {
+            "customType": "regex",
+            "fileMatch": [
+                "^charmcraft\\.yaml$"
+            ],
+            "matchStrings": [
+                " (?<currentValue>[^ ]+) +# renovate: charmcraft-rust-latest"
+            ],
+            "packageNameTemplate": "rust-lang/rust",
+            "datasourceTemplate": "github-releases",
+            "versioningTemplate": "semver"
+        }
+    ],
+    "schedule": [
+        "on the 2nd and 4th day instance on sunday"
+    ]
 }


### PR DESCRIPTION
To reduce the generated toil. This is the central file that we've been pointing to from our other repos:

I.e. https://github.com/canonical/kubeflow-profiles-operator/blob/3b5811e6f809ac6df1bb110f6bfc24418f8e9539/renovate.json