### PR TITLE
fix: allow custom default branches to retrieve modified rocks

### DIFF
--- a/.github/workflows/get-rocks-modified-and-build-scan-test-publish.yaml
+++ b/.github/workflows/get-rocks-modified-and-build-scan-test-publish.yaml
@@ -23,7 +23,7 @@ on:
         default: ""
         required: false
         type: string
-      base-branch:
+      base-ref:
         description: Branch, tag, or commit SHA against which the changes will be detected.
         required: false
         default: main
@@ -34,7 +34,7 @@ jobs:
     name: Get rockcraft paths modified
     uses: ./.github/workflows/get-rocks-modified.yaml
     with:
-      base-branch: ${{ inputs.base-branch }}
+      base-ref: ${{ inputs.base-ref }}
 
   build-scan-test-publish-rock:
     name: CI

--- a/.github/workflows/get-rocks-modified.yaml
+++ b/.github/workflows/get-rocks-modified.yaml
@@ -3,7 +3,7 @@ name: Get rocks modified
 on:
   workflow_call:
     inputs:
-      base-branch:
+      base-ref:
         description: Branch, tag, or commit SHA against which the changes will be detected.
         required: false
         default: main
@@ -48,4 +48,4 @@ jobs:
         id: filter
         with:
           filters: ${{ needs.get-all-rock-paths.outputs.paths}}
-          base: ${{ inputs.base-branch }}
+          base: ${{ inputs.base-ref }}


### PR DESCRIPTION
This PR aims to fix #119 by adding a new optional input parameter, `base-branch`, which is propagated down to `path-filters`.