### PR TITLE
fix: Update backport title to align with "Validation PR title" action

### DIFF
--- a/.github/workflows/backport-pr.yaml
+++ b/.github/workflows/backport-pr.yaml
@@ -40,7 +40,7 @@ jobs:
         with:
           copy_assignees: true
           copy_requested_reviewers: true
-          pull_title: "${pull_title} (backport ${pull_number})"
+          pull_title: "${pull_title} (backport #${pull_number})"
           github_token: ${{ secrets.GH_TOKEN }}
           experimental: '{"conflict_resolution": "draft_commit_conflicts"}'
           git_committer_name: ${{ steps.import-gpg.outputs.name }}


### PR DESCRIPTION
This PR updates the title for the automated backports to align with the "Validate PR title" action, as specified in https://github.com/canonical/admission-webhook-operator/pull/244#issuecomment-4081456713