### PR TITLE
fix: Add author as reviewer to `backport-pr`

### DIFF
--- a/.github/workflows/backport-pr.yaml
+++ b/.github/workflows/backport-pr.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v6
       - name: Import and configure the GPG key
         id: import-gpg
-        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec
+        uses: crazy-max/ghaction-import-gpg@92a10f995fd20944e1cae9a2e86e62dafe4f6171
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
@@ -39,6 +39,7 @@ jobs:
         uses: korthout/backport-action@v4
         with:
           copy_assignees: true
+          add_author_as_reviewer: true
           copy_requested_reviewers: true
           pull_title: "${pull_title} (backport #${pull_number})"
           github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/backport-pr.yaml
+++ b/.github/workflows/backport-pr.yaml
@@ -40,7 +40,6 @@ jobs:
         with:
           copy_assignees: true
           add_author_as_reviewer: true
-          copy_requested_reviewers: true
           pull_title: "${pull_title} (backport #${pull_number})"
           github_token: ${{ secrets.GH_TOKEN }}
           experimental: '{"conflict_resolution": "draft_commit_conflicts"}'


### PR DESCRIPTION
Closes #128 

This PR sets the `add_author_as_reviewer` input to true in the upstream `korthout/backport-action@v4` action. This essentially copies the `author` of the original PR to the new backports PR. 

The `copy_requested_reviewers` input is not actually needed, since it only copies reviewers that have NOT yet submitted a review.

We also update the commit hash of the `ghaction-import-gpg` to update the `Node.js` version used, since we are already getting deprecation warnings in the previous hash, see https://github.com/canonical/admission-webhook-operator/actions/runs/23339085261.