### PR TITLE
fix: skip CI rock when no rock is changed

### DIFF
--- a/.github/workflows/get-rocks-modified-and-build-scan-test-publish.yaml
+++ b/.github/workflows/get-rocks-modified-and-build-scan-test-publish.yaml
@@ -39,6 +39,7 @@ jobs:
   build-scan-test-publish-rock:
     name: CI
     needs: get-rock-paths-modified
+    if: ${{ needs.get-rock-paths-modified.outputs.paths != '[]' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This PR fixes #43 by skipping the rock CI when no rock is updated.