### PR TITLE
fix: Use `GITHUB_TOKEN` instead of `GH_TOKEN` for git commands in backport-pr action

### DIFF
--- a/.github/workflows/backport-pr.yaml
+++ b/.github/workflows/backport-pr.yaml
@@ -41,7 +41,7 @@ jobs:
           copy_assignees: true
           add_author_as_reviewer: true
           pull_title: "${pull_title} (backport #${pull_number})"
-          token: ${{ secret.GH_TOKEN }}
+          token: ${{ secrets.GH_TOKEN }}
           github_token: ${{ secrets.GH_TOKEN }}
           experimental: '{"conflict_resolution": "draft_commit_conflicts"}'
           git_committer_name: ${{ steps.import-gpg.outputs.name }}

--- a/.github/workflows/backport-pr.yaml
+++ b/.github/workflows/backport-pr.yaml
@@ -27,7 +27,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
       - name: Debug — check git config
-        run: git config --get-regexp 'url\.'
+        run: |
+          curl -s -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/user | grep '"login"'
+          curl -s -H "Authorization: token $GH_TOKEN" https://api.github.com/user | grep '"login"'
       - name: Import and configure the GPG key
         id: import-gpg
         uses: crazy-max/ghaction-import-gpg@92a10f995fd20944e1cae9a2e86e62dafe4f6171

--- a/.github/workflows/backport-pr.yaml
+++ b/.github/workflows/backport-pr.yaml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+      - name: Debug — check git config
+        run: git config --get-regexp 'url\.'
       - name: Import and configure the GPG key
         id: import-gpg
         uses: crazy-max/ghaction-import-gpg@92a10f995fd20944e1cae9a2e86e62dafe4f6171

--- a/.github/workflows/backport-pr.yaml
+++ b/.github/workflows/backport-pr.yaml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GH_TOKEN }}
       - name: Import and configure the GPG key
         id: import-gpg
         uses: crazy-max/ghaction-import-gpg@92a10f995fd20944e1cae9a2e86e62dafe4f6171
@@ -41,7 +43,6 @@ jobs:
           copy_assignees: true
           add_author_as_reviewer: true
           pull_title: "${pull_title} (backport #${pull_number})"
-          token: ${{ secrets.GH_TOKEN }}
           github_token: ${{ secrets.GH_TOKEN }}
           experimental: '{"conflict_resolution": "draft_commit_conflicts"}'
           git_committer_name: ${{ steps.import-gpg.outputs.name }}

--- a/.github/workflows/backport-pr.yaml
+++ b/.github/workflows/backport-pr.yaml
@@ -26,10 +26,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-      - name: Debug — check git config
-        run: |
-          curl -s -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/user | grep '"login"'
-          curl -s -H "Authorization: token $GH_TOKEN" https://api.github.com/user | grep '"login"'
       - name: Import and configure the GPG key
         id: import-gpg
         uses: crazy-max/ghaction-import-gpg@92a10f995fd20944e1cae9a2e86e62dafe4f6171
@@ -45,6 +41,7 @@ jobs:
           copy_assignees: true
           add_author_as_reviewer: true
           pull_title: "${pull_title} (backport #${pull_number})"
+          token: ${{ secret.GH_TOKEN }}
           github_token: ${{ secrets.GH_TOKEN }}
           experimental: '{"conflict_resolution": "draft_commit_conflicts"}'
           git_committer_name: ${{ steps.import-gpg.outputs.name }}


### PR DESCRIPTION
## Summary
This PR updates the `backport-pr.yaml` action to use the `GH_TOKEN` instead of the default `GITHUB_TOKEN`. This is needed to execute `git push` with the elevated permissions.

## Explanation
Some logs from an example run:
```
...
/usr/bin/git push --set-upstream origin backport-402-to-track/0.18
warning: not sending a push certificate since the receiving end does not support --signed push
To https://github.com/canonical/katib-operators
 ! [remote rejected] backport-402-to-track/0.18 -> backport-402-to-track/0.18 (refusing to allow a GitHub App to create or update workflow `.github/workflows/ci.yaml` without `workflows` permission)
error: failed to push some refs to 'https://github.com/canonical/katib-operators'
Branch backport-402-to-track/0.18 may already exist, fetching it instead to recover previous run
/usr/bin/git fetch --depth=1 origin backport-402-to-track/0.18
fatal: couldn't find remote ref backport-402-to-track/0.18
Git push to origin failed for track/0.18 with exitcode 1
Create comment: Git push to origin failed for track/0.18 with exitcode 1
```

We can see that the `git push` failed here. This occurs whenever a backport updates one of the files under `github/workflows`, which counts as an action to "created or update a workflow", as we had for example in https://github.com/canonical/katib-operators/pull/402/changes. Because this needs a token with the `workflow` permission, a fix here is to force the action to use a properly-scoped token for the `git` commands, instead of the default `GITHUB_TOKEN` that is used.

The `token` input is one of the inputs defined in the `checkout` action, see https://github.com/actions/checkout#usage. This token is persisted in the git config since the default setting for `persist_credentials` is set to true.

Closes #139 

