### PR TITLE
chore: parametrize Rockcraft channel and clean up rocks CI

### DIFF
--- a/.github/workflows/build-rock.yaml
+++ b/.github/workflows/build-rock.yaml
@@ -43,9 +43,10 @@ jobs:
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.source-branch }}
+          persist-credentials: false
 
       - uses: canonical/craft-actions/rockcraft-pack@main
         id: rockcraft
@@ -85,7 +86,7 @@ jobs:
           echo "rock-filename=$ROCK" >> "$GITHUB_OUTPUT"
         working-directory: ${{ inputs.rock-dir }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.metadata.outputs.rock-artifact }}
           path: ${{ inputs.rock-dir }}/${{ steps.metadata.outputs.rock-filename }}

--- a/.github/workflows/build-rock.yaml
+++ b/.github/workflows/build-rock.yaml
@@ -68,7 +68,7 @@ jobs:
           sudo iptables -F FORWARD
           sudo iptables -P FORWARD ACCEPT
           
-          sudo snap install rockcraft --classic
+          sudo snap install rockcraft --classic --channel=${{ inputs.rockcraft-channel }}
           
           cd ${{ inputs.rock-dir || '.' }}
           sudo --user "$USER" rockcraft pack ${{ inputs.rockcraft-extra-args }}

--- a/.github/workflows/build-scan-test-publish-rock.yaml
+++ b/.github/workflows/build-scan-test-publish-rock.yaml
@@ -9,17 +9,17 @@ on:
         type: string
       rockcraft-channel:
         description: "Rockcraft channel e.g. latest/stable"
-        required: true
+        required: false
         default: "latest/stable"
         type: string
       microk8s-channel:
         description: "Microk8s channel e.g. 1.32/stable"
-        required: true
+        required: false
         default: "1.32/stable"
         type: string
       juju-channel:
         description: "Juju channel e.g. 3.6/stable"
-        required: true
+        required: false
         default: "3.6/stable"
         type: string
       python-version:
@@ -51,6 +51,7 @@ jobs:
       rock-artifact: ${{ needs.build.outputs.rock-artifact }}
       rock-reference: ${{ needs.resolve-image-tag.outputs.rock-reference }}
       rock-filename: ${{ needs.build.outputs.rock-filename }}
+      rockcraft-channel: ${{ inputs.rockcraft-channel }}
 
   sanity-tests:
     needs: [build, resolve-image-tag]
@@ -60,6 +61,7 @@ jobs:
       rock-artifact: ${{ needs.build.outputs.rock-artifact }}
       rock-reference: ${{ needs.resolve-image-tag.outputs.rock-reference }}
       rock-filename: ${{ needs.build.outputs.rock-filename }}
+      rockcraft-channel: ${{ inputs.rockcraft-channel }}
 
   integration-tests:
     needs: [build, resolve-image-tag]
@@ -72,6 +74,7 @@ jobs:
       microk8s-channel: ${{ inputs.microk8s-channel }}
       juju-channel: ${{ inputs.juju-channel }}
       python-version: ${{ inputs.python-version }}
+      rockcraft-channel: ${{ inputs.rockcraft-channel }}
 
   publish:
     if: ${{ github.event_name == 'push' }}
@@ -82,6 +85,7 @@ jobs:
       rock-artifact: ${{ needs.build.outputs.rock-artifact }}
       rock-filename: ${{ needs.build.outputs.rock-filename }}
       full-image-tag: ${{ needs.resolve-image-tag.outputs.full-image-tag }}
+      rockcraft-channel: ${{ inputs.rockcraft-channel }}
 
   integrate-on-pr:
     if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/build-scan-test-publish-rock.yaml
+++ b/.github/workflows/build-scan-test-publish-rock.yaml
@@ -71,10 +71,7 @@ jobs:
       rock-artifact: ${{ needs.build.outputs.rock-artifact }}
       rock-reference: ${{ needs.resolve-image-tag.outputs.rock-reference }}
       rock-filename: ${{ needs.build.outputs.rock-filename }}
-      microk8s-channel: ${{ inputs.microk8s-channel }}
-      juju-channel: ${{ inputs.juju-channel }}
       python-version: ${{ inputs.python-version }}
-      rockcraft-channel: ${{ inputs.rockcraft-channel }}
 
   publish:
     if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/get-rocks-modified-and-build-scan-test-publish.yaml
+++ b/.github/workflows/get-rocks-modified-and-build-scan-test-publish.yaml
@@ -10,12 +10,12 @@ on:
         type: string
       microk8s-channel:
         description: "Microk8s channel e.g. 1.32/stable"
-        required: true
+        required: false
         default: "1.32/stable"
         type: string
       juju-channel:
         description: "Juju channel e.g. 3.6/stable"
-        required: true
+        required: false
         default: "3.6/stable"
         type: string
       python-version:

--- a/.github/workflows/get-rocks-modified.yaml
+++ b/.github/workflows/get-rocks-modified.yaml
@@ -21,7 +21,10 @@ jobs:
       paths: ${{ steps.find.outputs.paths}}
     steps:
       - name: Checkout repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       - name: Get all rockcraft.yaml paths using find
         id: find
         run: |
@@ -43,8 +46,11 @@ jobs:
       rock_paths: ${{ steps.filter.outputs.changes }}
     steps:
       - name: Checkout repository code
-        uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v2
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: ${{ needs.get-all-rock-paths.outputs.paths}}

--- a/.github/workflows/integrate-rock.yaml
+++ b/.github/workflows/integrate-rock.yaml
@@ -44,7 +44,9 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install charmed-analytics-ci
         run: pipx install charmed-analytics-ci==1.2.0
@@ -97,7 +99,7 @@ jobs:
           fi
 
       - name: Import and configure the GPG key for chaci
-        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec
+        uses: crazy-max/ghaction-import-gpg@92a10f995fd20944e1cae9a2e86e62dafe4f6171
         with:
           gpg_private_key: ${{ secrets.CHACI_GPG_PRIVATE }}
           passphrase: ${{ secrets.CHACI_GPG_PASSPHRASE }}

--- a/.github/workflows/integrate-rock.yaml
+++ b/.github/workflows/integrate-rock.yaml
@@ -66,10 +66,10 @@ jobs:
             fi
           else
             if [[ "${{ inputs.event-name }}" == "pull_request" ]]; then
-              echo "target_branch=main" >> $GITHUB_OUTPUT
+              echo "target_branch=${{ github.base_ref }}" >> $GITHUB_OUTPUT
               echo "dry_run=--dry-run" >> $GITHUB_OUTPUT
             else
-              echo "target_branch=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
+              echo "target_branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
               echo "dry_run=" >> $GITHUB_OUTPUT
             fi
           fi

--- a/.github/workflows/integration-test-rock.yaml
+++ b/.github/workflows/integration-test-rock.yaml
@@ -20,14 +20,19 @@ on:
         description: "Filename of the .rock file"
         required: true
         type: string
+      rockcraft-channel:
+        description: "Rockcraft channel e.g. latest/stable"
+        required: false
+        default: "latest/stable"
+        type: string
       microk8s-channel:
         description: "Microk8s channel e.g. 1.32/stable"
-        required: true
+        required: false
         default: "1.32/stable"
         type: string
       juju-channel:
         description: "Juju channel e.g. 3.6/stable"
-        required: true
+        required: false
         default: "3.6/stable"
         type: string
       source-branch:
@@ -43,7 +48,7 @@ on:
 
 jobs:
   integration-tests:
-    name: Test ${{ inputs.rock-reference }}
+    name: Integration test ${{ inputs.rock-reference }}
     runs-on: ubuntu-24.04
     steps:
       - name: Maximise GH runner space
@@ -55,7 +60,7 @@ jobs:
           ref: ${{ inputs.source-branch }}
 
       - name: Install Rockcraft
-        run: sudo snap install rockcraft --classic --edge
+        run: sudo snap install rockcraft --classic --channel=${{ inputs.rockcraft-channel }}
 
       - uses: actions/download-artifact@v4
         with:
@@ -79,16 +84,6 @@ jobs:
       - name: Clean up .rock file
         run: rm ${{ inputs.rock-filename }}
 
-      - name: Install dependencies
-        run: pipx install tox
-
-      - name: Setup environment
-        run: |
-          sudo apt-get remove -y docker-ce docker-ce-cli containerd.io
-          sudo rm -rf /run/containerd
-          sudo snap install concierge --classic
-          sudo concierge prepare --trace
-
       - name: Integration tests
         run: |
           if [[ "${{ inputs.python-version }}" ]]
@@ -98,41 +93,3 @@ jobs:
             tox -e integration
           fi
         working-directory: ./${{ inputs.tests-dir }}
-
-      - name: Save debug artifacts
-        if: failure() || cancelled()
-        uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main
-
-      - name: Setup Debug Artifact Collection
-        if: failure() || cancelled()
-        run: mkdir tmp
-
-      - name: Collect charmcraft logs
-        if: failure() || cancelled()
-        run: |
-          cat /home/runner/.local/state/charmcraft/log/charmcraft-*.log | tee tmp/charmcraft.log
-
-      - name: Collect Juju status
-        if: failure() || cancelled()
-        run: juju status | tee tmp/juju-status.txt
-
-      - name: Collect Juju log
-        if: failure() || cancelled()
-        run: juju debug-log --replay --no-tail | tee tmp/juju-status.txt
-
-      - name: Collect Kube status
-        if: failure() || cancelled()
-        run: |
-          kubectl get all -A | tee tmp/kube-summary.txt
-          kubectl describe pods -A | tee tmp/kube-pods.txt
-          kubectl describe virtualservices -A | tee tmp/kube-virtualservices.txt
-          kubectl describe gateways -A | tee tmp/kube-gateways.txt
-          kubectl describe deployments -A | tee tmp/kube-deployments.txt
-          kubectl describe replicasets -A | tee tmp/kubectl-replicasets.txt
-
-      - name: Upload debug artifacts
-        if: failure() || cancelled()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-run-artifacts
-          path: tmp

--- a/.github/workflows/integration-test-rock.yaml
+++ b/.github/workflows/integration-test-rock.yaml
@@ -55,20 +55,21 @@ jobs:
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.source-branch }}
+          persist-credentials: false
 
       - name: Install Rockcraft
         run: sudo snap install rockcraft --classic --channel=${{ inputs.rockcraft-channel }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.rock-artifact }}
 
       - name: Set up Python version from input
         if: ${{ inputs.python-version }}
-        uses: actions/setup-python@v5.3.0
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ inputs.python-version }}
 

--- a/.github/workflows/integration-test-rock.yaml
+++ b/.github/workflows/integration-test-rock.yaml
@@ -106,3 +106,11 @@ jobs:
             tox -e integration
           fi
         working-directory: ./${{ inputs.tests-dir }}
+
+      - name: Get Juju status
+        if: always()
+        run: juju status --relations
+
+      - name: Save debug artifacts
+        if: failure()
+        uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main

--- a/.github/workflows/integration-test-rock.yaml
+++ b/.github/workflows/integration-test-rock.yaml
@@ -20,21 +20,6 @@ on:
         description: "Filename of the .rock file"
         required: true
         type: string
-      rockcraft-channel:
-        description: "Rockcraft channel e.g. latest/stable"
-        required: false
-        default: "latest/stable"
-        type: string
-      microk8s-channel:
-        description: "Microk8s channel e.g. 1.32/stable"
-        required: false
-        default: "1.32/stable"
-        type: string
-      juju-channel:
-        description: "Juju channel e.g. 3.6/stable"
-        required: false
-        default: "3.6/stable"
-        type: string
       source-branch:
         description: "Github branch to checkout. If blank, it will use default values."
         default: '' # For default behaviour, see https://github.com/actions/checkout/tree/v4/#usage
@@ -47,8 +32,31 @@ on:
         type: string
 
 jobs:
+  check-integration-tests:
+    name: Check for integration test files
+    runs-on: ubuntu-24.04
+    outputs:
+      has-integration-tests: ${{ steps.check.outputs.has-integration-tests }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.source-branch }}
+          persist-credentials: false
+
+      - name: Check for integration test files
+        id: check
+        run: |
+          if find "${{ inputs.tests-dir }}" -name '*integration*' | grep -q .; then
+            echo "has-integration-tests=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-integration-tests=false" >> "$GITHUB_OUTPUT"
+          fi
+
   integration-tests:
-    name: Integration test ${{ inputs.rock-reference }}
+    name: Integration tests
+    needs: check-integration-tests
+    if: needs.check-integration-tests.outputs.has-integration-tests == 'true'
     runs-on: ubuntu-24.04
     steps:
       - name: Maximise GH runner space
@@ -60,9 +68,6 @@ jobs:
           ref: ${{ inputs.source-branch }}
           persist-credentials: false
 
-      - name: Install Rockcraft
-        run: sudo snap install rockcraft --classic --channel=${{ inputs.rockcraft-channel }}
-
       - uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.rock-artifact }}
@@ -72,6 +77,13 @@ jobs:
         uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ inputs.python-version }}
+
+      - name: Setup environment
+        run: |
+          sudo apt-get remove -y docker-ce docker-ce-cli containerd.io
+          sudo rm -rf /run/containerd
+          sudo snap install concierge --classic
+          sudo concierge prepare --trace
 
       - name: Install dependencies
         run: pip install tox

--- a/.github/workflows/publish-rock.yaml
+++ b/.github/workflows/publish-rock.yaml
@@ -34,19 +34,20 @@ jobs:
       published-image: ${{ steps.push.outputs.image }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.source-branch }}
+          persist-credentials: false
 
       - name: Install Rockcraft
         run: sudo snap install rockcraft --classic --channel=${{ inputs.rockcraft-channel }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.rock-artifact }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3.0.0
+        uses: docker/login-action@v4.2.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/publish-rock.yaml
+++ b/.github/workflows/publish-rock.yaml
@@ -20,6 +20,11 @@ on:
         default: ''
         required: false
         type: string
+      rockcraft-channel:
+        description: "Rockcraft channel e.g. latest/stable"
+        required: false
+        default: "latest/stable"
+        type: string
 
 jobs:
   publish:
@@ -34,7 +39,7 @@ jobs:
           ref: ${{ inputs.source-branch }}
 
       - name: Install Rockcraft
-        run: sudo snap install rockcraft --classic
+        run: sudo snap install rockcraft --classic --channel=${{ inputs.rockcraft-channel }}
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/resolve-image-tag.yaml
+++ b/.github/workflows/resolve-image-tag.yaml
@@ -32,7 +32,9 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install yq
         run: sudo snap install yq

--- a/.github/workflows/sanity-test-rock.yaml
+++ b/.github/workflows/sanity-test-rock.yaml
@@ -25,6 +25,12 @@ on:
         default: '' # For default behaviour, see https://github.com/actions/checkout/tree/v4/#usage
         required: false
         type: string
+      rockcraft-channel:
+        description: "Rockcraft channel e.g. latest/stable"
+        required: false
+        default: "latest/stable"
+        type: string
+
 jobs:
   sanity-tests:
     name: Sanity test ${{ inputs.rock-reference }}
@@ -36,7 +42,7 @@ jobs:
           ref: ${{ inputs.source-branch }}
       
       - name: Install Rockcraft
-        run: sudo snap install rockcraft --classic --edge
+        run: sudo snap install rockcraft --classic --channel=${{ inputs.rockcraft-channel }}
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/sanity-test-rock.yaml
+++ b/.github/workflows/sanity-test-rock.yaml
@@ -37,14 +37,15 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.source-branch }}
-      
+          persist-credentials: false
+
       - name: Install Rockcraft
         run: sudo snap install rockcraft --classic --channel=${{ inputs.rockcraft-channel }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.rock-artifact }}
 

--- a/.github/workflows/scan-rock.yaml
+++ b/.github/workflows/scan-rock.yaml
@@ -16,6 +16,12 @@ on:
         description: "Filename of the .rock file"
         required: true
         type: string
+      rockcraft-channel:
+        description: "Rockcraft channel e.g. latest/stable"
+        required: false
+        default: "latest/stable"
+        type: string
+
 jobs:
   scan:
     name: Scan ${{ inputs.rock-reference }}
@@ -30,7 +36,7 @@ jobs:
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
       
       - name: Install Rockcraft
-        run: sudo snap install rockcraft --classic --edge
+        run: sudo snap install rockcraft --classic --channel=${{ inputs.rockcraft-channel }}
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/scan-rock.yaml
+++ b/.github/workflows/scan-rock.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Rockcraft
         run: sudo snap install rockcraft --classic --channel=${{ inputs.rockcraft-channel }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.rock-artifact }}
 
@@ -67,7 +67,7 @@ jobs:
         run: cat trivy-report-${{ inputs.rock-artifact }}.json
 
       - name: Upload Trivy reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: trivy-report-${{ inputs.rock-artifact }}
           path: trivy-report-${{ inputs.rock-artifact }}.json

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -26,3 +26,5 @@ host:
   snaps:
     charmcraft:
       channel: 3.x/stable
+    rockcraft:
+      channel: latest/edge


### PR DESCRIPTION
This PR allows to parametrize rockcraft channel in inputs and cleans the rocks CI actions. The total saved time is around 30%.

This PR completely removes the setup environment step with concierge, since neither K8s or Juju are required. In addition, debug steps for Juju, Charmcraft, K8s, are removed since these snaps are not even installed.

This PR also removes the wrong `required: true` when a default is defined. This is an intermediate step required to fully remove microk8s from our CI: this option will be removed in rocks repositories, and then finally removed from here with another PR.

This PR also fixes an issue in `chaci` rock integration for which dry-run integration PRs would be always created against `main` and actual integration PRs are failing when the source branch is in the form of `track/*` (or more in general contains multiple `/`). Example of failure can be found [here](https://github.com/canonical/kubeflow-trainer-rocks/actions/runs/26560370495/job/78243617645).

<details>
<summary>New dry-run</summary>

```
[DRY-RUN] Would commit to branch 'integrate-kubeflow-trainer-2.1.0-8483ba9' with message: chore: integrate rock image kubeflow-trainer:2.1.0-8483ba9
[DRY-RUN] Would open PR: integrate-kubeflow-trainer-2.1.0-8483ba9 → track/2.1
```
</details>

This PR also bumps the version of many actions to use Node24.

This PR has been tested [here](https://github.com/canonical/kubeflow-trainer-rocks/actions/runs/26574292882).