### PR TITLE
chore: clean-up scheduled rock build template

### DIFF
--- a/templates/on-schedule-rocks-template.yaml
+++ b/templates/on-schedule-rocks-template.yaml
@@ -30,9 +30,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install yq
-        run: sudo snap install yq
-
       - name: Build ref matrix from automatic_backport_tracks.yaml
         id: compute
         run: |

--- a/templates/on-schedule-rocks-template.yaml
+++ b/templates/on-schedule-rocks-template.yaml
@@ -35,7 +35,7 @@ jobs:
         run: |
           file=.github/automatic_backport_tracks.yaml
           if [ -f "$file" ]; then
-            refs=$(yq -o=json '["main"] + .automatic_backport_tracks' "$file" | jq -c .)
+            refs=$(yq -o=json -I=0 '["main"] + .automatic_backport_tracks' "$file")
           else
             echo "::warning file=${file}::${file} not found; falling back to main only"
             refs='["main"]'


### PR DESCRIPTION
This PR cleans the scheduled rock build template workflow:
* do not install `yq` as already shipped in `ubuntu-24.04`
* avoid redundant piping in `yq` to produce compact yaml