### PR TITLE
feat: Skip backport automation if pull request author is `ckfbot`

### DIFF
--- a/.github/workflows/populate-labels.yaml
+++ b/.github/workflows/populate-labels.yaml
@@ -39,7 +39,7 @@ on:
 
 jobs:
   populate-labels:
-    if: github.event.pull_request.user.login != 'ckfbot'
+    if: github.event.pull_request && github.event.pull_request.user.login != 'ckfbot'
     runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/populate-labels.yaml
+++ b/.github/workflows/populate-labels.yaml
@@ -39,6 +39,7 @@ on:
 
 jobs:
   populate-labels:
+    if: github.event.pull_request.user.login != 'ckfbot'
     runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Summary

This PR updates the `populate-labels` action to only trigger if the author of the raised PR is *not* the `ckfbot`, which is the account we use for automation.

Note that if the event that triggered this workflow is *not* a PR, then `github.event.pull_request.user.login` is an empty string, so the condition is `True` and executes normally.

Closes #146 