### PR TITLE
feat: Add get-all-rock-refs-and-build-scan-test-publish.yaml action

### DIFF
--- a/.github/workflows/get-all-rock-refs-and-build-scan-test-publish.yaml
+++ b/.github/workflows/get-all-rock-refs-and-build-scan-test-publish.yaml
@@ -1,0 +1,48 @@
+# Reusable workflow to
+# It uses a `.automatic_backport_tracks` file to find all relevant branches
+# and for each branch found (+ main), builds and publishes rocks
+
+name: Build and publish rocks for all refs
+
+on:
+  workflow_call:
+
+jobs:
+  list-refs:
+    name: Compute ref matrix
+    runs-on: ubuntu-24.04
+    outputs:
+      refs: ${{ steps.compute.outputs.refs }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Build ref matrix from automatic_backport_tracks.yaml
+        id: compute
+        run: |
+          file=.github/automatic_backport_tracks.yaml
+          if [ -f "$file" ]; then
+            refs=$(yq -o=json -I=0 '["main"] + .automatic_backport_tracks' "$file")
+          else
+            echo "::warning file=${file}::${file} not found; falling back to main only"
+            refs='["main"]'
+          fi
+          echo "Refs: ${refs}"
+          echo "refs=${refs}" >> "$GITHUB_OUTPUT"
+
+  build-scan-test-publish:
+    name: Build, scan, test and publish rocks (${{ matrix.ref }})
+    needs: list-refs
+    strategy:
+      fail-fast: false
+      matrix:
+        ref: ${{ fromJson(needs.list-refs.outputs.refs) }}
+    uses: ./.github/workflows/get-all-rocks-and-build-scan-test-publish.yaml
+    permissions:
+      contents: read
+      issues: write
+    secrets: inherit
+    with:
+      base-ref: ${{ matrix.ref }}

--- a/.github/workflows/get-all-rock-refs-and-build-scan-test-publish.yaml
+++ b/.github/workflows/get-all-rock-refs-and-build-scan-test-publish.yaml
@@ -19,6 +19,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install yq
+        run: sudo snap install yq
+
       - name: Build ref matrix from automatic_backport_tracks.yaml
         id: compute
         run: |

--- a/.github/workflows/get-all-rock-refs-and-build-scan-test-publish.yaml
+++ b/.github/workflows/get-all-rock-refs-and-build-scan-test-publish.yaml
@@ -1,6 +1,6 @@
-# Reusable workflow to
-# It uses a `.automatic_backport_tracks` file to find all relevant branches
-# and for each branch found (+ main), builds and publishes rocks
+# Reusable workflow to build, scan, test and publish rocks across all supported refs.
+# It uses the `.github/automatic_backport_tracks.yaml` file (when present) to find relevant branches,
+# and for each branch found (plus `main`), builds and publishes rocks.
 
 name: Build and publish rocks for all refs
 


### PR DESCRIPTION
This PR adds a `get-all-rock-refs-and-build-scan-test-publish.yaml` action which essentially:
- Finds all branch we "support" via `.automatic_backport_tracks.yaml`
- For each ref, build and publish all rocks in repository (using `get-all-rocks-and-build-scan-test-publish.yaml`)

This way we can just have this part in the individual rock repos:
```yaml
.github/workflows/scheduled-rebuild-rocks.yaml:
name: Scheduled rebuild rocks
on:
  schedule:
    - cron: '0 4 1 * *'   # 1st of each month, 04:00 UTC
  workflow_dispatch:
jobs:
  scheduled-rebuild-rocks:
    uses: canonical/charmed-kubeflow-workflows/.github/workflows/get-all-rock-refs-and-build-scan-test-publish.yaml@main
    permissions:
      contents: read
      issues: write
    secrets: inherit
```

Closes #149